### PR TITLE
TL5 - allow configure UT test directory in the arguments

### DIFF
--- a/TL5/tests/ut/from-file-test.4.lm
+++ b/TL5/tests/ut/from-file-test.4.lm
@@ -118,9 +118,7 @@ func setup-test()
 
 
 test test-compiler()
-  if sys.argv.length > 1
-    sys.argv[1].equal(user "--trace")->(var flag-trace)
-
+  setup-arguments()
   var String{256} filename
   set-test-file-name(user filename, user "input", user "5.lm")
   file-open-read.mocked(user filename)->(owner input-file)

--- a/TL5/tests/ut/global-tests.4.lm
+++ b/TL5/tests/ut/global-tests.4.lm
@@ -2,6 +2,23 @@
 module tl5-compiler-tests
 
 
+var Bool arguments-set
+var String{1024} test-base-dir
+
+func setup-arguments()
+  if arguments-set
+    return
+  for n in 1:sys.argv.length
+    user String arg(user sys.argv[n])
+    if arg.equal(user "--trace")
+      flag-trace := true
+    else-if arg[0] != '-' and test-base-dir.length = 0
+      test-base-dir.new(user arg)
+  if test-base-dir.length = 0
+    sys.getenv(user "TEST_DIR", user test-base-dir)
+  arguments-set := true
+
+
 func assert-string-slice(
     user String expected,
     user String actual,
@@ -53,9 +70,8 @@ func assert-string(user String expected, user String actual)
 
 func set-test-file-name(
     user String filename, user String base-name, user String suffix)
-  var String{1024} base-dir
-  if sys.getenv(user "TEST_DIR", user base-dir)
-    filename.new(user base-dir)
+  setup-arguments()
+  filename.new(user test-base-dir)
   filename.concat(user base-name)
   filename.append(copy '.')
   filename.concat(user suffix)


### PR DESCRIPTION
Changes: allow configure UT test directory in the arguments

- [x] Changes fully completed + unit tested + integration tested + documented
