### PR TITLE
Bootstrap up to TL2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build/
+.build/
 .test
 actual.c
 actual.txt

--- a/TL0/BUILD
+++ b/TL0/BUILD
@@ -14,7 +14,13 @@ cc_binary(
     srcs = [
         "tl0-compiler.c",
     ],
-    copts = ["-std=c89"],
     visibility = ["//visibility:public"],
     deps = [":lumi"],
+    copts = [
+        "-std=c89",
+        "-Wno-unused-label",
+        "-Wno-unused-variable",
+        "-Wno-unused-but-set-variable",
+        "-Wno-misleading-indentation",
+    ],
 )

--- a/TL0/BUILD
+++ b/TL0/BUILD
@@ -14,8 +14,6 @@ cc_binary(
     srcs = [
         "tl0-compiler.c",
     ],
-    visibility = ["//visibility:public"],
-    deps = [":lumi"],
     copts = [
         "-std=c89",
         "-Wno-unused-label",
@@ -23,4 +21,6 @@ cc_binary(
         "-Wno-unused-but-set-variable",
         "-Wno-misleading-indentation",
     ],
+    visibility = ["//visibility:public"],
+    deps = [":lumi"],
 )

--- a/TL0/BUILD
+++ b/TL0/BUILD
@@ -1,0 +1,20 @@
+cc_library(
+    name = "lumi",
+    srcs = [
+        "tl0-file.c",
+        "tl0-string.c",
+    ],
+    hdrs = ["tl0-c-api.h"],
+    strip_include_prefix = "",
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "compiler",
+    srcs = [
+        "tl0-compiler.c",
+    ],
+    copts = ["-std=c89"],
+    visibility = ["//visibility:public"],
+    deps = [":lumi"],
+)

--- a/TL1/BUILD
+++ b/TL1/BUILD
@@ -1,0 +1,24 @@
+load("//:lumi.bzl", "lumi_binary")
+
+cc_library(
+    name = "lumi",
+    srcs = ["lumi.1.c"],
+    hdrs = ["lumi.1.h"],
+    # This is a workaround for https://github.com/bazelbuild/bazel/issues/6337.
+    includes = ["."],
+    # strip_include_prefix allows dependending rules to include headers without
+    # the prefix.
+    strip_include_prefix = "",
+    visibility = [
+        "//TL2:__pkg__",
+        "//lumi-command:__pkg__",
+    ],
+)
+
+lumi_binary(
+    name = "compiler",
+    srcs = ["tl1-compiler.0.lm"],
+    compiler = "//TL0:compiler",
+    lumi_version = 0,
+    visibility = ["//visibility:public"],
+)

--- a/TL2/BUILD
+++ b/TL2/BUILD
@@ -1,0 +1,24 @@
+load("//:lumi.bzl", "lumi_binary")
+
+cc_library(
+    name = "lumi",
+    srcs = ["lumi.2.c"],
+    hdrs = ["lumi.2.h"],
+    # This is a workaround for https://github.com/bazelbuild/bazel/issues/6337.
+    includes = ["."],
+    # strip_include_prefix allows dependending rules to include headers without
+    # the prefix.
+    strip_include_prefix = "",
+    visibility = [
+        "//TL3:__pkg__",
+        "//lumi-command:__pkg__",
+    ],
+)
+
+lumi_binary(
+    name = "compiler",
+    srcs = ["tl2-compiler.1.lm"],
+    compiler = "//TL1:compiler",
+    lumi_version = 1,
+    visibility = ["//visibility:public"],
+)

--- a/TL2/BUILD
+++ b/TL2/BUILD
@@ -4,6 +4,11 @@ cc_library(
     name = "lumi",
     srcs = ["lumi.2.c"],
     hdrs = ["lumi.2.h"],
+    copts = [
+        "-Wno-unused-label",
+        "-Wno-unused-variable",
+        "-Wno-unused-but-set-variable",
+    ],
     # This is a workaround for https://github.com/bazelbuild/bazel/issues/6337.
     includes = ["."],
     # strip_include_prefix allows dependending rules to include headers without

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -3,5 +3,4 @@ load("//:lumi.bzl", "lumi_binary")
 lumi_binary(
     name = "hello-world",
     srcs = ["hello-world.5.lm"],
-    deps = [],
 )

--- a/lumi.bzl
+++ b/lumi.bzl
@@ -73,7 +73,7 @@ def lumi_binary(name, srcs, **kwargs):
     deps = []
     if lumi_version in (2, 3, 4):
         fail("lumi_binary does not support Lumi version {}"
-             .format(lumi_version))
+            .format(lumi_version))
 
     if lumi_version == 0:
         deps += ["//TL0:lumi"]
@@ -88,6 +88,8 @@ def lumi_binary(name, srcs, **kwargs):
             "-Wno-unused-label",
             "-Wno-unused-variable",
             "-Wno-unused-but-set-variable",
+            "-Wno-misleading-indentation",
+            "-Wno-parentheses",
         ],
         **kwargs
     )

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CC?=gcc
-BUILDDIR=build
+BUILDDIR=.build
 INSTALLDIR=/usr/local/bin/
 EXECUTABLES=lumi $(foreach n,0 1 2 3 4 5,tl$(n)-compiler)
 EXECUTABLE_PATHS=$(addprefix $(BUILDDIR)/,$(EXECUTABLES))


### PR DESCRIPTION
This allows Bazel to compile the TL2 compiler using TL1 compiler using TL0 compiler written in C.

Unfortunately, the way TL2 compiler *runs* is that it creates the generated files in the same directory as the input (without accepting a parameter) and Bazel can't handle that nicely without a lot of effort. I think this is still merge-worthy to have the first few steps automated.