### PR TITLE
TL5 - make globals safe again

### DIFF
--- a/TL5/expression/assign.4.lm
+++ b/TL5/expression/assign.4.lm
@@ -59,6 +59,11 @@ class AssignExpression(Expression)
         if access-is-owner(copy self.target.access) or
                 self.target.access = Access.TEMP
             refs.check-writing-memory(user self.value)
+            if self.target.access = Access.TEMP and value-path?
+                if not value-path.variable.parent?
+                    self.syntax-error(
+                            user "cannot take temporary owner from global",
+                            user value-path.variable.name)
             if not is-forward-move
                 if self.target.access = Access.TEMP
                     refs.mark-full-path-block-invalid(user value-path)

--- a/TL5/expression/operator.4.lm
+++ b/TL5/expression/operator.4.lm
@@ -316,9 +316,12 @@ class SwapOperatorExpression(BinaryExpression)
 
 
     func dynamic check-memory(user ReferenceMemoryList refs)
-        self.assign-right-to-left.check-operands-memory(user refs)
-        refs.clear-invalid-reference(
-                user self.right-expression.result-type.reference-path)
+        if access-is-temp(copy self.left-expression.access)
+            refs.check-writing-memory(user self.left-expression)
+            refs.check-writing-memory(user self.right-expression)
+        else
+            self.left-expression.check-memory(user refs)
+            self.right-expression.check-memory(user refs)
 
     func dynamic write()
         self.assign-left-to-aux.write-assign()

--- a/TL5/global/memory.4.lm
+++ b/TL5/global/memory.4.lm
@@ -236,10 +236,13 @@ struct ReferenceMemoryList
     
     func check-node-reference(
             user ReferencePath reference-path, user SyntaxTreeNode node)
-        if self.is-invalid(user reference-path) or self.reference-inside(
-                user reference-path, user self.written-owner-references)
+        if self.is-invalid(user reference-path)
             node.syntax-error-ref(
                     user "using invalid reference", user reference-path)
+        if self.reference-inside(
+                user reference-path, user self.written-owner-references)
+            node.syntax-error-ref(
+                    user "using modified reference", user reference-path)
         if reference-path?
             self.read-owner-references.add(owner reference-path.copy-new())
     

--- a/TL5/global/type-instance.4.lm
+++ b/TL5/global/type-instance.4.lm
@@ -270,12 +270,17 @@ struct TypeInstance
                         user "into static type",
                         user target.type-data.name)
             if self.reference-path?
-                if self.reference-path.field? and
-                        not self.reference-path.is-conditional()
-                    assert node?
-                    node.syntax-error-ref(
-                            user "cannot move non-conditional owner field",
-                            user self.reference-path)
+                if not self.reference-path.is-conditional()
+                    if self.reference-path.field?
+                        assert node?
+                        node.syntax-error-ref(
+                                user "cannot move non-conditional owner field",
+                                user self.reference-path)
+                    if not self.reference-path.variable.parent?
+                        assert node?
+                        node.syntax-error-ref(
+                                user "cannot move non-conditional global owner",
+                                user self.reference-path)
         if (not access-is-user(copy target-access) and
                 access-is-user(copy self-access)) or
                 (target-access = Access.S-VAR and self-access = Access.VAR)

--- a/TL5/statement/variable.4.lm
+++ b/TL5/statement/variable.4.lm
@@ -139,11 +139,16 @@ class SyntaxTreeVariable(SyntaxTreeCode)
                     user self.type-instance.type-data.name)
         if access-is-only-var(copy self.access)
             self.type-instance.check-sequence(user self)
-        if not self.parent? and not self.parent-type? and
-                (self.access = Access.USER or self.access = Access.TEMP)
-            self.syntax-error(
-                    user "global variables cannot have access",
-                    user glob.access-names[self.access])
+        if not self.parent? and not self.parent-type?
+            if self.access = Access.USER or self.access = Access.TEMP
+                self.syntax-error(
+                        user "global variables cannot have access",
+                        user glob.access-names[self.access])
+            if not self.type-instance.type-data.is-primitive and
+                    not self.type-instance.conditional and
+                    not self.is-initialized
+                self.syntax-error-msg(
+                        user "non-conditional global variable not initialized")
         if self.parent-type?
             if self.access = Access.USER or self.access = Access.TEMP
                 self.syntax-error(

--- a/TL5/statement/variable.4.lm
+++ b/TL5/statement/variable.4.lm
@@ -139,6 +139,11 @@ class SyntaxTreeVariable(SyntaxTreeCode)
                     user self.type-instance.type-data.name)
         if access-is-only-var(copy self.access)
             self.type-instance.check-sequence(user self)
+        if not self.parent? and not self.parent-type? and
+                (self.access = Access.USER or self.access = Access.TEMP)
+            self.syntax-error(
+                    user "global variables cannot have access",
+                    user glob.access-names[self.access])
         if self.parent-type?
             if self.access = Access.USER or self.access = Access.TEMP
                 self.syntax-error(

--- a/TL5/syntax-tree/root.4.lm
+++ b/TL5/syntax-tree/root.4.lm
@@ -127,7 +127,7 @@ class SyntaxTreeRoot(GlobalNodes)
         else-if self.equal-and-space(user keyword, user "enum")
             self.enums.add(owner EnumData.parse-new(user _))
             
-        else-if self.equal-and-new-line(user keyword, user "main")
+        else-if keyword.equal(user "main")
             SyntaxTreeMainFunction.parse-new(user _)->(owner self.main-function)
             
         else-if self.equal-and-space(user keyword, user "native")
@@ -425,7 +425,11 @@ class SyntaxTreeMainFunction(SyntaxTreeFunction)
     func inst parse()
         self.my-module := glob.current-module
         string-new-copy(user "main")->(owner self.name)
-        self.arguments.has-error := true
+        if glob.last-char = '!'
+            self.arguments.has-error := true
+            glob.root.global-init.arguments.has-error := true
+            read-c()
+        self.expect-new-line(user "main")
         self.parse-body()
     
     func dynamic write()
@@ -434,6 +438,7 @@ class SyntaxTreeMainFunction(SyntaxTreeFunction)
         ; }
         ; MAIN_FUNC
         write(user "\nUSER_MAIN_HEADER")
+        self.arguments.has-error := true
         self.write-block()
         self.write-post-func()
         write(user "\nMAIN_FUNC\n")

--- a/TL5/tests/integration/test0.5.lm
+++ b/TL5/tests/integration/test0.5.lm
@@ -17,7 +17,7 @@ comment
 
 ; Test global variables
 var Int global-int(copy 23)
-user String global-string(user "a constant string")
+owner String global-string(owner String{32}(user "a constant string")!)
 
 var Array{TestEnum.length + LENGTH:Int} int-arr
 const Int LENGTH SIZE * 5
@@ -647,7 +647,7 @@ func ! test-switch()
     sys.println(user s2)!
 
 
-main
+main!
     test-simple-function()!
     test-ref-count()!
     test-error-handling(user _)!

--- a/TL5/tests/ut/expected.c
+++ b/TL5/tests/ut/expected.c
@@ -64,7 +64,7 @@ void ut_M_fun6(Int x, Int y, Int* n, Int* m);
 void ut_M_fun7(ut_M_Tb* tb, Ref_Manager* tb_Refman, ut_M_Tb_Dynamic* tb_Dynamic, ut_M_Tb** tbo, Ref_Manager** tbo_Refman, ut_M_Tb_Dynamic** tbo_Dynamic);
 void ut_M_fun8(char* s, int s_Max_length, int* s_Length, Ref_Manager* s_Refman);
 Returncode ut_M_fune(void);
-Returncode ut_M_mock(char** so, int* so_Max_length, int** so_Length, Ref_Manager** so_Refman, Int* io, ut_M_Test** to, Ref_Manager** to_Refman, ut_M_Tc** tco, Ref_Manager** tco_Refman, ut_M_Tc_Dynamic** tco_Dynamic);
+Returncode ut_M_mock(char* str, int str_Max_length, int* str_Length, char** so, int* so_Max_length, int** so_Length, Ref_Manager** so_Refman, Int* io, ut_M_Test** to, Ref_Manager** to_Refman, ut_M_Tc** tco, Ref_Manager** tco_Refman, ut_M_Tc_Dynamic** tco_Dynamic);
 Generic_Type_Dynamic ut_M_Test_dynamic = {(Dynamic_Del)ut_M_Test_Del};
 ut_M_Ta_Dynamic ut_M_Ta_dynamic = {(Dynamic_Del)ut_M_Ta_Del, ut_M_Ta_dyn};
 ut_M_Tb_Dynamic ut_M_Tb_dynamic = {{(Dynamic_Del)ut_M_Tb_Del, (void (*)(ut_M_Ta* self, ut_M_Ta_Dynamic* self_Dynamic))ut_M_Tb_dyn}};
@@ -74,9 +74,6 @@ Int ut_M_i = 0;
 Byte ut_M_bt = 0;
 Char ut_M_c = 0;
 Bool ut_M_b = 0;
-char* ut_M_str = NULL;
-int ut_M_str_Max_length = 0;
-int* ut_M_str_Length = &Lumi_empty_int;
 char* ut_M_ostr = NULL;
 int ut_M_ostr_Max_length = 0;
 int* ut_M_ostr_Length = &Lumi_empty_int;
@@ -234,7 +231,7 @@ LUMI_block0_cleanup:
     (void)0;
     return LUMI_err;
 }
-Returncode ut_M_mock(char** so, int* so_Max_length, int** so_Length, Ref_Manager** so_Refman, Int* io, ut_M_Test** to, Ref_Manager** to_Refman, ut_M_Tc** tco, Ref_Manager** tco_Refman, ut_M_Tc_Dynamic** tco_Dynamic) {
+Returncode ut_M_mock(char* str, int str_Max_length, int* str_Length, char** so, int* so_Max_length, int** so_Length, Ref_Manager** so_Refman, Int* io, ut_M_Test** to, Ref_Manager** to_Refman, ut_M_Tc** tco, Ref_Manager** tco_Refman, ut_M_Tc_Dynamic** tco_Dynamic) {
     Returncode LUMI_err = OK;
     unsigned LUMI_loop_depth = 1;
 LUMI_block0_cleanup:
@@ -328,41 +325,41 @@ char* aux_String_0 = NULL;
     int aux_String_0_Max_length = 0;
     int aux_String_0_Length[1] = {0};
     INIT_STRING_CONST(1, LUMI_block0_cleanup, aux_String_0, "some string");
-    ut_M_str_Max_length = aux_String_0_Max_length;
-    ut_M_str_Length = aux_String_0_Length;
-    ut_M_str = aux_String_0;
+    str_Max_length = aux_String_0_Max_length;
+    str_Length = aux_String_0_Length;
+    str = aux_String_0;
 /// @ test-string-expression-1
 char* aux_String_0 = NULL;
     int aux_String_0_Max_length = 0;
     int aux_String_0_Length[1] = {0};
     INIT_STRING_CONST(1, LUMI_block0_cleanup, aux_String_0, "\nstring\t\"with\\formatting\n");
-    ut_M_str_Max_length = aux_String_0_Max_length;
-    ut_M_str_Length = aux_String_0_Length;
-    ut_M_str = aux_String_0;
+    str_Max_length = aux_String_0_Max_length;
+    str_Length = aux_String_0_Length;
+    str = aux_String_0;
 /// @ test-string-expression-2
 char* aux_String_0 = NULL;
     int aux_String_0_Max_length = 0;
     int aux_String_0_Length[1] = {0};
     INIT_STRING_CONST(4, LUMI_block0_cleanup, aux_String_0, "linesplitstring");
-    ut_M_str_Max_length = aux_String_0_Max_length;
-    ut_M_str_Length = aux_String_0_Length;
-    ut_M_str = aux_String_0;
+    str_Max_length = aux_String_0_Max_length;
+    str_Length = aux_String_0_Length;
+    str = aux_String_0;
 /// @ test-string-expression-3
 char* aux_String_0 = NULL;
     int aux_String_0_Max_length = 0;
     int aux_String_0_Length[1] = {0};
     INIT_STRING_CONST(4, LUMI_block0_cleanup, aux_String_0, "multi\nline\nstring\n");
-    ut_M_str_Max_length = aux_String_0_Max_length;
-    ut_M_str_Length = aux_String_0_Length;
-    ut_M_str = aux_String_0;
+    str_Max_length = aux_String_0_Max_length;
+    str_Length = aux_String_0_Length;
+    str = aux_String_0;
 /// @ test-string-expression-4
 char* aux_String_0 = NULL;
     int aux_String_0_Max_length = 0;
     int aux_String_0_Length[1] = {0};
     INIT_STRING_CONST(2, LUMI_block0_cleanup, aux_String_0, "line split");
-    ut_M_str_Max_length = aux_String_0_Max_length;
-    ut_M_str_Length = aux_String_0_Length;
-    ut_M_str = aux_String_0;
+    str_Max_length = aux_String_0_Max_length;
+    str_Length = aux_String_0_Length;
+    str = aux_String_0;
 /// @ test-string-expression-e0
 no '"' around string constant ""aaa"
 /// @ test-string-expression-e1
@@ -375,9 +372,9 @@ indentation too short, expected 12 got 8
 indentation too short, expected 12 got 8
 /// @@ test-empty-expression
 /// @ test-empty-expression-0
-ut_M_str_Max_length = 0;
-    ut_M_str_Length = &Lumi_empty_int;
-    ut_M_str = NULL;
+str_Max_length = 0;
+    str_Length = &Lumi_empty_int;
+    str = NULL;
 /// @ test-empty-expression-1
 LUMI_inc_ref(NULL);
     LUMI_dec_ref(ut_M_t_Refman);
@@ -1534,9 +1531,9 @@ char* s = NULL;
     *so_Refman = NULL;
     *so_Length = &Lumi_empty_int;
 /// @ test-binary-expression-9
-ut_M_str_Max_length = *so_Max_length;
-    ut_M_str_Length = *so_Length;
-    ut_M_str = *so;
+str_Max_length = *so_Max_length;
+    str_Length = *so_Length;
+    str = *so;
 /// @ test-binary-expression-10
 ut_M_b = ((void*)ut_M_t == ut_M_ta) || ((void*)ut_M_tc != ut_M_tb);
 /// @ test-binary-expression-11
@@ -2047,8 +2044,8 @@ char* s = NULL;
     int s_Max_length = 0;
     int* s_Length = &Lumi_empty_int;
     Int aux_Int_0 = 0;
-    CHECK_REF(1, LUMI_block0_cleanup, ut_M_str)
-    String_length(ut_M_str, ut_M_str_Max_length, ut_M_str_Length, &(aux_Int_0));
+    CHECK_REF(1, LUMI_block0_cleanup, str)
+    String_length(str, str_Max_length, str_Length, &(aux_Int_0));
     INIT_NEW_STRING(1, LUMI_block0_cleanup, s, aux_Int_0);
 /// @ test-exclamation-expression-e0
 ignoring empty reference check
@@ -2603,12 +2600,20 @@ Int ut_M_x = 0;
 /// @ test-general-6
 char ut_M_s[12] = {0};
 int ut_M_s_Length[1] = {0};
+char ut_M_svs[12] = {0};
+int ut_M_svs_Length[1] = {0};
+Ref_Manager* ut_M_svs_Refman = NULL;
+char* ut_M_cs = NULL;
+int ut_M_cs_Max_length = 0;
+int* ut_M_cs_Length = &Lumi_empty_int;
 char* ut_M_us = NULL;
 int ut_M_us_Max_length = 0;
 int* ut_M_us_Length = &Lumi_empty_int;
+Ref_Manager* ut_M_us_Refman = NULL;
 char* ut_M_gs = NULL;
 int ut_M_gs_Max_length = 0;
 int* ut_M_gs_Length = &Lumi_empty_int;
+Ref_Manager* ut_M_gs_Refman = NULL;
 void new_Mock(Bool* allocate_success) { }
 Returncode delete_Mock(Ref self) { return OK; }
 USER_MAIN_HEADER {
@@ -2617,21 +2622,47 @@ USER_MAIN_HEADER {
     Int x = 0;
     char* aux_String_0 = NULL;
     int aux_String_0_Max_length = 0;
-    int aux_String_0_Length[1] = {0};
+    int* aux_String_0_Length = &Lumi_empty_int;
+    char* aux_String_1 = NULL;
+    int aux_String_1_Max_length = 0;
+    int aux_String_1_Length[1] = {0};
+    char* aux_String_2 = NULL;
+    int aux_String_2_Max_length = 0;
+    int* aux_String_2_Length = &Lumi_empty_int;
 #define LUMI_FUNC_NAME "global variable initialization"
 #define LUMI_FILE_NAME "mock.5.lm"
     /* initializing ut_M_s */
 #undef LUMI_FILE_NAME
 #define LUMI_FILE_NAME "mock.5.lm"
-    ut_M_us_Max_length = 12;
-    ut_M_us_Length = ut_M_s_Length;
-    ut_M_us = ut_M_s;
+    INIT_VAR_REFMAN(2, LUMI_block0_cleanup, ut_M_svs)
 #undef LUMI_FILE_NAME
 #define LUMI_FILE_NAME "mock.5.lm"
-    INIT_STRING_CONST(3, LUMI_block0_cleanup, aux_String_0, "global text");
-    ut_M_gs_Max_length = aux_String_0_Max_length;
-    ut_M_gs_Length = aux_String_0_Length;
-    ut_M_gs = aux_String_0;
+    INIT_STRING_CONST(3, LUMI_block0_cleanup, aux_String_1, "global text");
+    INIT_NEW_STRING(3, LUMI_block0_cleanup, aux_String_0, 12);
+    LUMI_err = String_copy(aux_String_0, 12, aux_String_0_Length, aux_String_1, *aux_String_1_Length);
+    ut_M_cs_Max_length = 12;
+    ut_M_cs_Length = aux_String_0_Length;
+    ut_M_cs = aux_String_0;
+    aux_String_0 = NULL;
+    aux_String_0_Length = &Lumi_empty_int;
+#undef LUMI_FILE_NAME
+#define LUMI_FILE_NAME "mock.5.lm"
+    INIT_NEW_STRING(4, LUMI_block0_cleanup, aux_String_2, 12);
+    LUMI_err = String_copy(aux_String_2, 12, aux_String_2_Length, ut_M_s, *ut_M_s_Length);
+    ut_M_us_Max_length = 12;
+    ut_M_us_Length = aux_String_2_Length;
+    ut_M_us = aux_String_2;
+    aux_String_2 = NULL;
+    aux_String_2_Length = &Lumi_empty_int;
+    INIT_NEW_REFMAN(4, LUMI_block0_cleanup, ut_M_us)
+#undef LUMI_FILE_NAME
+#define LUMI_FILE_NAME "mock.5.lm"
+    LUMI_inc_ref(ut_M_us_Refman);
+    LUMI_dec_ref(ut_M_gs_Refman);
+    ut_M_gs_Refman = ut_M_us_Refman;
+    ut_M_gs_Max_length = ut_M_us_Max_length;
+    ut_M_gs_Length = ut_M_us_Length;
+    ut_M_gs = ut_M_us;
 #undef LUMI_FILE_NAME
 #undef LUMI_FUNC_NAME
     x = 6;
@@ -2646,18 +2677,15 @@ void ut_M_fun(void);
 Returncode second_M_dummy(void);
 char ut_M_s[12] = {0};
 int ut_M_s_Length[1] = {0};
-char* ut_M_us = NULL;
-int ut_M_us_Max_length = 0;
-int* ut_M_us_Length = &Lumi_empty_int;
-int LUMI_file0_line_count[6] = {
-    -1,-1,-1,-1, 0,-1
+int LUMI_file0_line_count[5] = {
+    -1,-1,-1, 0,-1
 };
 File_Coverage LUMI_file_coverage[1] = {
-    {"mock.5.lm", 6, LUMI_file0_line_count}
+    {"mock.5.lm", 5, LUMI_file0_line_count}
 };
 void ut_M_fun(void) {
     unsigned LUMI_loop_depth = 1;
-    ++LUMI_file_coverage[0].line_count[4];
+    ++LUMI_file_coverage[0].line_count[3];
     String_clear(ut_M_s, 12, ut_M_s_Length);
 LUMI_block0_cleanup:
     (void)0;
@@ -2678,11 +2706,6 @@ USER_MAIN_HEADER {
 #define LUMI_FUNC_NAME "global variable initialization"
 #define LUMI_FILE_NAME "mock.5.lm"
     /* initializing ut_M_s */
-#undef LUMI_FILE_NAME
-#define LUMI_FILE_NAME "mock.5.lm"
-    ut_M_us_Max_length = 12;
-    ut_M_us_Length = ut_M_s_Length;
-    ut_M_us = ut_M_s;
 #undef LUMI_FILE_NAME
 #undef LUMI_FUNC_NAME
     LUMI_success &= LUMI_run_test("dummy", second_M_dummy);
@@ -2756,6 +2779,10 @@ unknown type "Error"
 unknown symbol "error"
 /// @ test-general-e13
 unexpected "["
+/// @ test-general-e14
+global variables cannot have access "user"
+/// @ test-general-e15
+global variables cannot have access "temp"
 /// @@ test-struct
 /// @ test-struct-0
 typedef struct ut_M_Test ut_M_Test;
@@ -3312,6 +3339,26 @@ LUMI_block0_cleanup:
     return LUMI_err;
 }
 MAIN_FUNC
+/// @ test-function-m1
+void new_Mock(Bool* allocate_success) { }
+Returncode delete_Mock(Ref self) { return OK; }
+USER_MAIN_HEADER {
+    Returncode LUMI_err = OK;
+    unsigned LUMI_loop_depth = 1;
+    char* s = NULL;
+    int s_Max_length = 0;
+    int* s_Length = &Lumi_empty_int;
+    CHECK_REF(3, LUMI_block0_cleanup, s)
+    String_clear(s, s_Max_length, s_Length);
+LUMI_block0_cleanup:
+    (void)0;
+    String_Del(s);
+    free(s);
+    return LUMI_err;
+}
+MAIN_FUNC
+/// @ test-function-me0
+error raised inside function not declared as error raising "main"
 /// @ test-function-e0
 expected space after "func", got "("
 /// @ test-function-e1
@@ -3833,9 +3880,9 @@ char* aux_String_0 = NULL;
     int* aux_String_0_Length = &Lumi_empty_int;
     CHECK_REF_REFMAN(1, LUMI_block0_cleanup, ut_M_arr, ut_M_arr_Refman)
     INIT_NEW_STRING(1, LUMI_block0_cleanup, aux_String_0, ut_M_arr[0]);
-    ut_M_str_Max_length = aux_String_0_Max_length;
-    ut_M_str_Length = aux_String_0_Length;
-    ut_M_str = aux_String_0;
+    str_Max_length = aux_String_0_Max_length;
+    str_Length = aux_String_0_Length;
+    str = aux_String_0;
 /// @ test-initialize-2
 Int* a = NULL;
     int a_Length = 0;

--- a/TL5/tests/ut/expected.c
+++ b/TL5/tests/ut/expected.c
@@ -1955,6 +1955,10 @@ swapping non assignable expression
 non matching types "Ta" and "Tc"
 /// @ test-swap-expression-e5
 cannot swap access "owner" with other access "strong"
+/// @ test-swap-expression-e6
+using invalid reference "invalid"
+/// @ test-swap-expression-e7
+using invalid reference "invalid"
 /// @@ test-question-expression
 /// @ test-question-expression-0
 ut_M_b = ut_M_ostr != NULL;
@@ -8685,9 +8689,9 @@ cannot move non-conditional owner field "t.s"
 /// @ test-memory-owner-e9
 using invalid reference "s"
 /// @ test-memory-owner-e12
-using invalid reference "t"
+using modified reference "t"
 /// @ test-memory-owner-e13
-using invalid reference "t.t"
+using modified reference "t.t"
 /// @ test-memory-owner-e14
 cannot modify owner field "s" in non-owner reference "tu.s"
 /// @ test-memory-owner-e15
@@ -8703,7 +8707,7 @@ using modified reference "s"
 /// @ test-memory-owner-e20
 using modified reference "s"
 /// @ test-memory-owner-e21
-using invalid reference "t"
+using modified reference "t"
 /// @ test-memory-owner-e22
 using modified reference "t"
 /// @ test-memory-owner-e23

--- a/TL5/tests/ut/expected.c
+++ b/TL5/tests/ut/expected.c
@@ -2620,6 +2620,12 @@ USER_MAIN_HEADER {
     Returncode LUMI_err = OK;
     unsigned LUMI_loop_depth = 1;
     Int x = 0;
+    char* ls = NULL;
+    int ls_Max_length = 0;
+    int* ls_Length = &Lumi_empty_int;
+    char* aux_String_0 = NULL;
+    int aux_String_0_Max_length = 0;
+    int* aux_String_0_Length = &Lumi_empty_int;
     char* aux_String_0 = NULL;
     int aux_String_0_Max_length = 0;
     int* aux_String_0_Length = &Lumi_empty_int;
@@ -2667,8 +2673,24 @@ USER_MAIN_HEADER {
 #undef LUMI_FUNC_NAME
     x = 6;
     x = 7;
+    INIT_NEW_STRING(9, LUMI_block0_cleanup, ls, 12);
+    aux_String_0_Max_length = 12;
+    aux_String_0_Length = ls_Length;
+    aux_String_0 = ls;
+    ls_Max_length = ut_M_cs_Max_length;
+    ls_Length = ut_M_cs_Length;
+    ls = ut_M_cs;
+    ut_M_cs_Max_length = 12;
+    ut_M_cs_Length = aux_String_0_Length;
+    ut_M_cs = aux_String_0;
+    aux_String_0 = NULL;
+    aux_String_0_Length = &Lumi_empty_int;
 LUMI_block0_cleanup:
     (void)0;
+    String_Del(aux_String_0);
+    free(aux_String_0);
+    String_Del(ls);
+    free(ls);
     return LUMI_err;
 }
 MAIN_FUNC
@@ -2783,6 +2805,12 @@ unexpected "["
 global variables cannot have access "user"
 /// @ test-general-e15
 global variables cannot have access "temp"
+/// @ test-general-e16
+non-conditional global variable not initialized
+/// @ test-general-e17
+cannot move non-conditional global owner "error"
+/// @ test-general-e18
+cannot move non-conditional global owner "error"
 /// @@ test-struct
 /// @ test-struct-0
 typedef struct ut_M_Test ut_M_Test;
@@ -9369,6 +9397,10 @@ using invalid reference "s"
 using invalid reference "t"
 /// @ test-memory-temp-e13
 using invalid reference "t"
+/// @ test-memory-temp-e14
+cannot take temporary owner from global "ostr"
+/// @ test-memory-temp-e15
+cannot take temporary owner from global "t"
 /// @@ test-memory-constructor
 /// @ test-memory-constructor-0
 typedef struct ut_M_NoConstructor ut_M_NoConstructor;

--- a/TL5/tests/ut/input.5.lm
+++ b/TL5/tests/ut/input.5.lm
@@ -36,7 +36,6 @@ var Int i
 var Byte bt
 var Char c
 var Bool b
-user String? str
 owner String? ostr
 weak Array?{Int} arr
 owner File? fobj
@@ -47,7 +46,7 @@ weak Tc? tc
 weak Data?{Test} d
 weak Array?{String} sarr
 
-func ! mock()->(strong String? so, var Int io, strong Test? to, weak Tc? tco)
+func ! mock(user String? str)->(strong String? so, var Int io, strong Test? to, weak Tc? tco)
 ; @@ test-int-expression
 ; @ c test-int-expression-0
 i := 0
@@ -1113,7 +1112,7 @@ new Sys error!
 Sys()
 ; @@ test-general
 ; @ g test-general-0
-user String str
+owner String? str
 ; @ g test-general-1
 
 
@@ -1144,14 +1143,15 @@ var Int x
 var Int x
 ; @ g test-general-6
 var String{12} s
-user String us(user s)
-user String gs(user "global text")
-main
+s-var String{12} svs!
+owner String cs(owner String{12}(user "global text")!)
+strong String us(strong String{12}(user s)!)
+weak String gs(weak us)
+main!
     var Int x(copy 6)
     x := 7
 ; @ tg test-general-7
 var String{12} s
-user String us(user s)
 func fun()
     s.clear()
 ; @-
@@ -1199,6 +1199,10 @@ user Error error
 var Int x(copy error)
 ; @ eg test-general-e13
 [ ; error
+; @ eg test-general-e14
+user String error
+; @ eg test-general-e15
+temp String error
 ; @@ test-struct
 ; @ g test-struct-0
 struct Test
@@ -1391,6 +1395,14 @@ func name(user Array{Array{String}} ai)->(owner Array?{Array{Int}} ao)
 ; @ g test-function-m0
 main
     var Int x
+; @ g test-function-m1
+main!
+    owner String? s
+    s!.clear()
+; @ eg test-function-me0
+main
+    owner String? s
+    s!.clear()
 ; @ eg test-function-e0
 func(
 ; @ eg test-function-e1
@@ -3868,27 +3880,35 @@ func ! fun(owner Test?{File} t, user File f)
     t := _
     f.putc(copy 'a')!
 ; @ eg test-memory-user-e35
-main
+main!
     owner String? so(owner String{12}()!)
     user String? su(user so)
     so := _
     su!.clear()
 ; @ ec test-memory-user-e36
+so := _
 assert! str?
 ; @ ec test-memory-user-e37
+so := _
 assert-error! str.clear()
 ; @ ec test-memory-user-e38
+so := _
 if str?
 ; @ ec test-memory-user-e39
+so := _
 for _ in str!.length():2
 ; @ ec test-memory-user-e40
+so := _
 for _ in 2:str!.length()
 ; @ ec test-memory-user-e41
+so := _
 for _ in str!
 ; @ ec test-memory-user-e42
+so := _
 if b
     str!.clear()
 ; @ ec test-memory-user-e43
+so := _
 if false
     str := ostr
 str!.clear()

--- a/TL5/tests/ut/input.5.lm
+++ b/TL5/tests/ut/input.5.lm
@@ -1150,6 +1150,8 @@ weak String gs(weak us)
 main!
     var Int x(copy 6)
     x := 7
+    new String{12} ls!
+    ls :=: cs
 ; @ tg test-general-7
 var String{12} s
 func fun()
@@ -1194,15 +1196,27 @@ var Int name
 func name()
 var Int name
 ; @ eg test-general-e11
-user Error error
+user Error? error
 ; @ eg test-general-e12
 var Int x(copy error)
 ; @ eg test-general-e13
 [ ; error
 ; @ eg test-general-e14
-user String error
+user String? error
 ; @ eg test-general-e15
-temp String error
+temp String? error
+; @ eg test-general-e16
+weak String error
+; @ eg test-general-e17
+owner String error(owner String{12}()!)
+func fun()->(owner String? s)
+    s := error
+main!
+; @ eg test-general-e18
+owner String error(owner String{12}()!)
+func fun(owner String s)
+main!
+    fun(owner error)
 ; @@ test-struct
 ; @ g test-struct-0
 struct Test
@@ -4061,6 +4075,14 @@ struct Test
 func ! fun(owner Test t)
     temp Test x(temp t.next!.next!)
     x.next := t.next
+; @ ec test-memory-temp-e14
+temp String? s(temp ostr)
+; @ eg test-memory-temp-e15
+struct Test
+    owner String? s
+owner Test? t
+func ! error()
+    temp String? s(temp t!.s)
 ; @@ test-memory-constructor
 ; @ g test-memory-constructor-0
 struct NoConstructor

--- a/TL5/tests/ut/input.5.lm
+++ b/TL5/tests/ut/input.5.lm
@@ -716,6 +716,14 @@ ta :=: tc
 new Test t1!
 strong Test t2(strong to!)
 t1 :=: t2
+; @ ec test-swap-expression-e6
+new String{4} valid!
+owner String invalid
+valid :=: invalid
+; @ ec test-swap-expression-e7
+new String{4} valid!
+owner String invalid
+invalid :=: valid
 ; @@ test-question-expression
 ; @ c test-question-expression-0
 b := ostr?
@@ -3510,7 +3518,8 @@ func ! fun(owner Test? t)
 ; @ eg test-memory-owner-e14
 struct Test
     owner String s
-    new()
+    new!()
+        self.s := String{4}()!
 func fun(owner Test t, user Test tu, owner String s, user String su)
     t.s :=: s
     su.clear()

--- a/TL5/tl5-compiler.c
+++ b/TL5/tl5-compiler.c
@@ -18193,16 +18193,31 @@ LUMI_cleanup:
 #define LUMI_FUNC_NAME "SwapOperatorExpression.check-memory"
 Returncode tl5_compiler_M_SwapOperatorExpression_check_memory(tl5_compiler_M_SwapOperatorExpression* self, Ref_Manager* self_Refman, tl5_compiler_M_SwapOperatorExpression_Dynamic* self_Dynamic, tl5_compiler_M_ReferenceMemoryList* refs, Ref_Manager* refs_Refman) {
     Returncode LUMI_err = OK;
+    Bool aux_Bool_0 = 0;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(refs_Refman);
     CHECK_REF(319, self, self_Refman)
-    LUMI_err = tl5_compiler_M_AssignExpression_check_operands_memory(&(self->assign_right_to_left), self_Refman, &tl5_compiler_M_AssignExpression_dynamic, refs, refs_Refman);
+    CHECK_REF(319, self->_base.left_expression, self->_base.left_expression_Refman)
+    LUMI_err = tl5_compiler_M_access_is_temp(self->_base.left_expression->access, &(aux_Bool_0));
     CHECK(319)
-    CHECK_REF(321, self, self_Refman)
-    CHECK_REF(321, self->_base._base.right_expression, self->_base._base.right_expression_Refman)
-    CHECK_REF(321, self->_base._base.right_expression->result_type, self->_base._base.right_expression->result_type_Refman)
-    LUMI_err = tl5_compiler_M_ReferenceMemoryList_clear_invalid_reference(refs, refs_Refman, self->_base._base.right_expression->result_type->reference_path, self->_base._base.right_expression->result_type->reference_path_Refman);
-    CHECK(320)
+    if (aux_Bool_0) {
+        CHECK_REF(320, self, self_Refman)
+        LUMI_err = tl5_compiler_M_ReferenceMemoryList_check_writing_memory(refs, refs_Refman, self->_base.left_expression, self->_base.left_expression_Refman, self->_base.left_expression_Dynamic);
+        CHECK(320)
+        CHECK_REF(321, self, self_Refman)
+        LUMI_err = tl5_compiler_M_ReferenceMemoryList_check_writing_memory(refs, refs_Refman, self->_base._base.right_expression, self->_base._base.right_expression_Refman, self->_base._base.right_expression_Dynamic);
+        CHECK(321)
+    }
+    else {
+            CHECK_REF(323, self, self_Refman)
+            if (self->_base.left_expression_Dynamic == NULL) RAISE(323, empty_object)
+            LUMI_err = self->_base.left_expression_Dynamic->_base.check_memory(&(self->_base.left_expression->_base), self->_base.left_expression_Refman, &(self->_base.left_expression_Dynamic->_base), refs, refs_Refman);
+            CHECK(323)
+            CHECK_REF(324, self, self_Refman)
+            if (self->_base._base.right_expression_Dynamic == NULL) RAISE(324, empty_object)
+            LUMI_err = self->_base._base.right_expression_Dynamic->_base.check_memory(&(self->_base._base.right_expression->_base), self->_base._base.right_expression_Refman, &(self->_base._base.right_expression_Dynamic->_base), refs, refs_Refman);
+            CHECK(324)
+        }
 LUMI_cleanup:
     LUMI_dec_ref(refs_Refman);
     LUMI_dec_ref(self_Refman);
@@ -18216,32 +18231,32 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_SwapOperatorExpression_write(tl5_compiler_M_SwapOperatorExpression* self, Ref_Manager* self_Refman, tl5_compiler_M_SwapOperatorExpression_Dynamic* self_Dynamic) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(324, self, self_Refman)
-    LUMI_err = tl5_compiler_M_AssignExpression_write_assign(&(self->assign_left_to_aux), self_Refman, &tl5_compiler_M_AssignExpression_dynamic);
-    CHECK(324)
-    CHECK_REF(325, self, self_Refman)
-    LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base._base._base.code_node, self->_base._base._base.code_node_Refman, self->_base._base._base.code_node_Dynamic);
-    CHECK(325)
-    CHECK_REF(326, self, self_Refman)
-    LUMI_err = tl5_compiler_M_AssignExpression_write_assign(&(self->assign_right_to_left), self_Refman, &tl5_compiler_M_AssignExpression_dynamic);
-    CHECK(326)
     CHECK_REF(327, self, self_Refman)
-    LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base._base._base.code_node, self->_base._base._base.code_node_Refman, self->_base._base._base.code_node_Dynamic);
+    LUMI_err = tl5_compiler_M_AssignExpression_write_assign(&(self->assign_left_to_aux), self_Refman, &tl5_compiler_M_AssignExpression_dynamic);
     CHECK(327)
     CHECK_REF(328, self, self_Refman)
-    LUMI_err = tl5_compiler_M_AssignExpression_write_assign(&(self->assign_aux_to_right), self_Refman, &tl5_compiler_M_AssignExpression_dynamic);
+    LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base._base._base.code_node, self->_base._base._base.code_node_Refman, self->_base._base._base.code_node_Dynamic);
     CHECK(328)
     CHECK_REF(329, self, self_Refman)
-    CHECK_REF(329, self->_base._base.right_expression, self->_base._base.right_expression_Refman)
-    CHECK_REF(329, self->_base._base.right_expression->result_type, self->_base._base.right_expression->result_type_Refman)
-    CHECK_REF(329, self->_base._base.right_expression->result_type->type_data, self->_base._base.right_expression->result_type->type_data_Refman)
+    LUMI_err = tl5_compiler_M_AssignExpression_write_assign(&(self->assign_right_to_left), self_Refman, &tl5_compiler_M_AssignExpression_dynamic);
+    CHECK(329)
+    CHECK_REF(330, self, self_Refman)
+    LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base._base._base.code_node, self->_base._base._base.code_node_Refman, self->_base._base._base.code_node_Dynamic);
+    CHECK(330)
+    CHECK_REF(331, self, self_Refman)
+    LUMI_err = tl5_compiler_M_AssignExpression_write_assign(&(self->assign_aux_to_right), self_Refman, &tl5_compiler_M_AssignExpression_dynamic);
+    CHECK(331)
+    CHECK_REF(332, self, self_Refman)
+    CHECK_REF(332, self->_base._base.right_expression, self->_base._base.right_expression_Refman)
+    CHECK_REF(332, self->_base._base.right_expression->result_type, self->_base._base.right_expression->result_type_Refman)
+    CHECK_REF(332, self->_base._base.right_expression->result_type->type_data, self->_base._base.right_expression->result_type->type_data_Refman)
     if (! self->_base._base.right_expression->result_type->type_data->is_primitive) {
-        CHECK_REF(330, self, self_Refman)
+        CHECK_REF(333, self, self_Refman)
         LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base._base._base.code_node, self->_base._base._base.code_node_Refman, self->_base._base._base.code_node_Dynamic);
-        CHECK(330)
-        CHECK_REF(331, self, self_Refman)
+        CHECK(333)
+        CHECK_REF(334, self, self_Refman)
         LUMI_err = tl5_compiler_M_Expression_write_assign_null(self->aux_variable, self->aux_variable_Refman, self->aux_variable_Dynamic);
-        CHECK(331)
+        CHECK(334)
     }
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
@@ -33003,37 +33018,46 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_ReferenceMemoryList_check_node_reference(tl5_compiler_M_ReferenceMemoryList* self, Ref_Manager* self_Refman, tl5_compiler_M_ReferencePath* reference_path, Ref_Manager* reference_path_Refman, tl5_compiler_M_SyntaxTreeNode* node, Ref_Manager* node_Refman, tl5_compiler_M_SyntaxTreeNode_Dynamic* node_Dynamic) {
     Returncode LUMI_err = OK;
     Bool aux_Bool_0 = 0;
-    Bool aux_Bool_1 = 0;
     String aux_String_0_Var = {0};
     String* aux_String_0 = NULL;
     Ref_Manager* aux_String_0_Refman = NULL;
+    Bool aux_Bool_1 = 0;
+    String aux_String_1_Var = {0};
+    String* aux_String_1 = NULL;
+    Ref_Manager* aux_String_1_Refman = NULL;
     tl5_compiler_M_ReferencePath* aux_ReferencePath_0 = NULL;
     Ref_Manager* aux_ReferencePath_0_Refman = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(reference_path_Refman);
     LUMI_inc_ref(node_Refman);
-    CHECK_REF(240, self, self_Refman)
-    LUMI_err = tl5_compiler_M_ReferenceMemoryList_reference_inside(self, self_Refman, reference_path, reference_path_Refman, &(self->written_owner_references), self_Refman, &(aux_Bool_0));
+    LUMI_err = tl5_compiler_M_ReferenceMemoryList_is_invalid(self, self_Refman, reference_path, reference_path_Refman, &(aux_Bool_0));
     CHECK(239)
-    LUMI_err = tl5_compiler_M_ReferenceMemoryList_is_invalid(self, self_Refman, reference_path, reference_path_Refman, &(aux_Bool_1));
-    CHECK(239)
-    if (aux_Bool_1 || aux_Bool_0) {
-        INIT_STRING_CONST(242, aux_String_0, "using invalid reference");
+    if (aux_Bool_0) {
+        INIT_STRING_CONST(241, aux_String_0, "using invalid reference");
         LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error_ref(node, node_Refman, node_Dynamic, aux_String_0, aux_String_0_Refman, reference_path, reference_path_Refman);
-        CHECK(241)
+        CHECK(240)
+    }
+    CHECK_REF(243, self, self_Refman)
+    LUMI_err = tl5_compiler_M_ReferenceMemoryList_reference_inside(self, self_Refman, reference_path, reference_path_Refman, &(self->written_owner_references), self_Refman, &(aux_Bool_1));
+    CHECK(242)
+    if (aux_Bool_1) {
+        INIT_STRING_CONST(245, aux_String_1, "using modified reference");
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error_ref(node, node_Refman, node_Dynamic, aux_String_1, aux_String_1_Refman, reference_path, reference_path_Refman);
+        CHECK(244)
     }
     if (reference_path != NULL && reference_path_Refman->value != NULL) {
-        CHECK_REF(244, self, self_Refman)
+        CHECK_REF(247, self, self_Refman)
         LUMI_err = tl5_compiler_M_ReferencePath_copy_new(reference_path, reference_path_Refman, &(aux_ReferencePath_0), &(aux_ReferencePath_0_Refman));
-        CHECK(244)
+        CHECK(247)
         LUMI_err = tl5_compiler_M_List_add(&(self->read_owner_references), self_Refman, aux_ReferencePath_0, aux_ReferencePath_0_Refman, &tl5_compiler_M_ReferencePath_dynamic);
         aux_ReferencePath_0 = NULL;
         aux_ReferencePath_0_Refman = NULL;
-        CHECK(244)
+        CHECK(247)
     }
 LUMI_cleanup:
     tl5_compiler_M_ReferencePath_Del(aux_ReferencePath_0);
     LUMI_owner_dec_ref(aux_ReferencePath_0_Refman);
+    LUMI_var_dec_ref(aux_String_1_Refman);
     LUMI_var_dec_ref(aux_String_0_Refman);
     LUMI_dec_ref(node_Refman);
     LUMI_dec_ref(reference_path_Refman);
@@ -33062,27 +33086,27 @@ Returncode tl5_compiler_M_ReferenceMemoryList_check_user(tl5_compiler_M_Referenc
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(expression_Refman);
-    CHECK_REF(247, expression, expression_Refman)
-    CHECK_REF(247, expression->result_type, expression->result_type_Refman)
+    CHECK_REF(250, expression, expression_Refman)
+    CHECK_REF(250, expression->result_type, expression->result_type_Refman)
     exp_path = expression->result_type->reference_path;
     exp_path_Refman = expression->result_type->reference_path_Refman;
     LUMI_inc_ref(exp_path_Refman);
     if (! (exp_path != NULL && exp_path_Refman->value != NULL)) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(250, exp_path, exp_path_Refman)
+    CHECK_REF(253, exp_path, exp_path_Refman)
     if (! (exp_path->variable != NULL && exp_path->variable_Refman->value != NULL)) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(252, exp_path, exp_path_Refman)
-    CHECK_REF(252, exp_path->variable, exp_path->variable_Refman)
-    CHECK_REF(252, exp_path, exp_path_Refman)
+    CHECK_REF(255, exp_path, exp_path_Refman)
+    CHECK_REF(255, exp_path->variable, exp_path->variable_Refman)
+    CHECK_REF(255, exp_path, exp_path_Refman)
     if ((exp_path->field != NULL && exp_path->field_Refman->value != NULL) || (exp_path->variable->access != tl5_compiler_M_Access_USER)) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(254, self, self_Refman)
+    CHECK_REF(257, self, self_Refman)
     LUMI_err = tl5_compiler_M_NameMap_iter(&(self->user_references), self_Refman, &(aux_NameMapIterator_0), &(aux_NameMapIterator_0_Refman));
-    CHECK(254)
+    CHECK(257)
     aux_Ref_Manager = aux_NameMapIterator_1_Refman;
     aux_NameMapIterator_1_Refman = aux_NameMapIterator_0_Refman;
     LUMI_inc_ref(aux_NameMapIterator_1_Refman);
@@ -33092,16 +33116,16 @@ Returncode tl5_compiler_M_ReferenceMemoryList_check_user(tl5_compiler_M_Referenc
     while (true) {
         Bool variable_Has = false;
         LUMI_err = tl5_compiler_M_NameMapIterator_has(aux_NameMapIterator_1, aux_NameMapIterator_1_Refman, &(variable_Has));
-        CHECK(254)
+        CHECK(257)
         if (!variable_Has) break;
         LUMI_err = tl5_compiler_M_NameMapIterator_get(aux_NameMapIterator_1, aux_NameMapIterator_1_Refman, (void*)&(variable), &(variable_Refman), (void*)&(variable_Dynamic));
-        CHECK(254)
-        CHECK_REF(255, exp_path, exp_path_Refman)
+        CHECK(257)
+        CHECK_REF(258, exp_path, exp_path_Refman)
         if ((void*)variable == exp_path->variable) {
             goto LUMI_cleanup;
         }
         LUMI_err = tl5_compiler_M_NameMapIterator_next(aux_NameMapIterator_1, aux_NameMapIterator_1_Refman);
-        CHECK(254)
+        CHECK(257)
     }
     aux_Ref_Manager = aux_NameMapIterator_1_Refman;
     aux_NameMapIterator_1_Refman = NULL;
@@ -33109,9 +33133,9 @@ Returncode tl5_compiler_M_ReferenceMemoryList_check_user(tl5_compiler_M_Referenc
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     aux_NameMapIterator_1 = NULL;
-    INIT_STRING_CONST(258, aux_String_0, "using potentially illegal user reference");
+    INIT_STRING_CONST(261, aux_String_0, "using potentially illegal user reference");
     LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error_ref(&(expression->_base), expression_Refman, &(expression_Dynamic->_base), aux_String_0, aux_String_0_Refman, exp_path, exp_path_Refman);
-    CHECK(257)
+    CHECK(260)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_0_Refman);
     LUMI_dec_ref(aux_NameMapIterator_1_Refman);
@@ -33146,16 +33170,16 @@ Returncode tl5_compiler_M_ReferenceMemoryList_check_output(tl5_compiler_M_Refere
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(output_Refman);
-    CHECK_REF(261, output, output_Refman)
+    CHECK_REF(264, output, output_Refman)
     if (output->access != tl5_compiler_M_Access_USER) {
         goto LUMI_cleanup;
     }
-    if (output_Dynamic == NULL) RAISE(264, empty_object)
+    if (output_Dynamic == NULL) RAISE(267, empty_object)
     LUMI_err = output_Dynamic->get_variable(output, output_Refman, output_Dynamic, &(output_variable), &(output_variable_Refman), &(output_variable_Dynamic));
-    CHECK(264)
-    CHECK_REF(265, self, self_Refman)
+    CHECK(267)
+    CHECK_REF(268, self, self_Refman)
     LUMI_err = tl5_compiler_M_NameMap_iter(&(self->user_references), self_Refman, &(aux_NameMapIterator_0), &(aux_NameMapIterator_0_Refman));
-    CHECK(265)
+    CHECK(268)
     aux_Ref_Manager = aux_NameMapIterator_1_Refman;
     aux_NameMapIterator_1_Refman = aux_NameMapIterator_0_Refman;
     LUMI_inc_ref(aux_NameMapIterator_1_Refman);
@@ -33165,15 +33189,15 @@ Returncode tl5_compiler_M_ReferenceMemoryList_check_output(tl5_compiler_M_Refere
     while (true) {
         Bool variable_Has = false;
         LUMI_err = tl5_compiler_M_NameMapIterator_has(aux_NameMapIterator_1, aux_NameMapIterator_1_Refman, &(variable_Has));
-        CHECK(265)
+        CHECK(268)
         if (!variable_Has) break;
         LUMI_err = tl5_compiler_M_NameMapIterator_get(aux_NameMapIterator_1, aux_NameMapIterator_1_Refman, (void*)&(variable), &(variable_Refman), (void*)&(variable_Dynamic));
-        CHECK(265)
+        CHECK(268)
         if ((void*)variable == output_variable) {
             goto LUMI_cleanup;
         }
         LUMI_err = tl5_compiler_M_NameMapIterator_next(aux_NameMapIterator_1, aux_NameMapIterator_1_Refman);
-        CHECK(265)
+        CHECK(268)
     }
     aux_Ref_Manager = aux_NameMapIterator_1_Refman;
     aux_NameMapIterator_1_Refman = NULL;
@@ -33181,10 +33205,10 @@ Returncode tl5_compiler_M_ReferenceMemoryList_check_output(tl5_compiler_M_Refere
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     aux_NameMapIterator_1 = NULL;
-    INIT_STRING_CONST(269, aux_String_0, "returning potentially illegal user output");
-    CHECK_REF(270, output_variable, output_variable_Refman)
+    INIT_STRING_CONST(272, aux_String_0, "returning potentially illegal user output");
+    CHECK_REF(273, output_variable, output_variable_Refman)
     LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(output->_base), output_Refman, &(output_Dynamic->_base), aux_String_0, aux_String_0_Refman, output_variable->name, output_variable->name_Refman);
-    CHECK(268)
+    CHECK(271)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_0_Refman);
     LUMI_dec_ref(aux_NameMapIterator_1_Refman);
@@ -33221,14 +33245,14 @@ Returncode tl5_compiler_M_DeleteGroup_new(tl5_compiler_M_DeleteGroup* self, Ref_
     aux_List_0_Refman = deleting_types_Refman;
     deleting_types = NULL;
     deleting_types_Refman = NULL;
-    CHECK_REF(278, self, self_Refman)
+    CHECK_REF(281, self, self_Refman)
     tl5_compiler_M_List_Del(self->deleting_types);
     LUMI_owner_dec_ref(self->deleting_types_Refman);
     self->deleting_types_Refman = aux_List_0_Refman;
     self->deleting_types = aux_List_0;
     aux_List_0 = NULL;
     aux_List_0_Refman = NULL;
-    CHECK_REF(279, self, self_Refman)
+    CHECK_REF(282, self, self_Refman)
     self->delete_all = delete_all;
 LUMI_cleanup:
     tl5_compiler_M_List_Del(aux_List_0);
@@ -33248,11 +33272,11 @@ Returncode tl5_compiler_M_DeleteGroup_add_deleting(tl5_compiler_M_DeleteGroup* s
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(type_instance_Refman);
     LUMI_err = tl5_compiler_M_DeleteGroup_add_specific_deleting_type(self, self_Refman, type_instance, type_instance_Refman);
-    CHECK(282)
-    CHECK_REF(283, type_instance, type_instance_Refman)
-    CHECK_REF(283, type_instance->type_data, type_instance->type_data_Refman)
+    CHECK(285)
+    CHECK_REF(286, type_instance, type_instance_Refman)
+    CHECK_REF(286, type_instance->type_data, type_instance->type_data_Refman)
     LUMI_err = tl5_compiler_M_DeleteGroup_extend(self, self_Refman, type_instance->type_data->delete_group, type_instance->type_data->delete_group_Refman);
-    CHECK(283)
+    CHECK(286)
 LUMI_cleanup:
     LUMI_dec_ref(type_instance_Refman);
     LUMI_dec_ref(self_Refman);
@@ -33277,9 +33301,9 @@ Returncode tl5_compiler_M_DeleteGroup_extend(tl5_compiler_M_DeleteGroup* self, R
     if (! (other != NULL && other_Refman->value != NULL)) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(288, other, other_Refman)
+    CHECK_REF(291, other, other_Refman)
     LUMI_err = tl5_compiler_M_List_iter(other->deleting_types, other->deleting_types_Refman, &(aux_ListIterator_0), &(aux_ListIterator_0_Refman));
-    CHECK(288)
+    CHECK(291)
     aux_Ref_Manager = aux_ListIterator_1_Refman;
     aux_ListIterator_1_Refman = aux_ListIterator_0_Refman;
     LUMI_inc_ref(aux_ListIterator_1_Refman);
@@ -33289,14 +33313,14 @@ Returncode tl5_compiler_M_DeleteGroup_extend(tl5_compiler_M_DeleteGroup* self, R
     while (true) {
         Bool deleting_type_Has = false;
         LUMI_err = tl5_compiler_M_ListIterator_has(aux_ListIterator_1, aux_ListIterator_1_Refman, &(deleting_type_Has));
-        CHECK(288)
+        CHECK(291)
         if (!deleting_type_Has) break;
         LUMI_err = tl5_compiler_M_ListIterator_get(aux_ListIterator_1, aux_ListIterator_1_Refman, (void*)&(deleting_type), &(deleting_type_Refman), &dynamic_Void);
-        CHECK(288)
+        CHECK(291)
         LUMI_err = tl5_compiler_M_DeleteGroup_add_specific_deleting_type(self, self_Refman, deleting_type, deleting_type_Refman);
-        CHECK(289)
+        CHECK(292)
         LUMI_err = tl5_compiler_M_ListIterator_next(aux_ListIterator_1, aux_ListIterator_1_Refman);
-        CHECK(288)
+        CHECK(291)
     }
     aux_Ref_Manager = aux_ListIterator_1_Refman;
     aux_ListIterator_1_Refman = NULL;
@@ -33333,39 +33357,39 @@ Returncode tl5_compiler_M_DeleteGroup_add_specific_deleting_type(tl5_compiler_M_
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(type_instance_base_Refman);
-    CHECK_REF(292, self, self_Refman)
+    CHECK_REF(295, self, self_Refman)
     if (self->delete_all) {
         goto LUMI_cleanup;
     }
-    INIT_NEW(294, type_instance, LUMI_alloc(sizeof(tl5_compiler_M_TypeInstance)));
+    INIT_NEW(297, type_instance, LUMI_alloc(sizeof(tl5_compiler_M_TypeInstance)));
     LUMI_err = tl5_compiler_M_TypeInstance_copy(type_instance_base, type_instance_base_Refman, type_instance, type_instance_Refman);
-    CHECK(295)
-    CHECK_REF(296, type_instance, type_instance_Refman)
+    CHECK(298)
+    CHECK_REF(299, type_instance, type_instance_Refman)
     type_instance->conditional = false;
-    CHECK_REF(297, self, self_Refman)
-    CHECK_REF(297, self->deleting_types, self->deleting_types_Refman)
+    CHECK_REF(300, self, self_Refman)
+    CHECK_REF(300, self->deleting_types, self->deleting_types_Refman)
     node = self->deleting_types->first;
     node_Refman = self->deleting_types->first_Refman;
     LUMI_inc_ref(node_Refman);
     while (true) {
         if (!(node != NULL && node_Refman->value != NULL)) break;
-        CHECK_REF(300, node, node_Refman)
+        CHECK_REF(303, node, node_Refman)
         LUMI_err = tl5_compiler_M_TypeInstance_can_be_assigned_to(type_instance, type_instance_Refman, node->item, node->item_Refman, &(aux_Bool_0));
-        CHECK(300)
+        CHECK(303)
         if (aux_Bool_0) {
             goto LUMI_cleanup;
         }
-        CHECK_REF(302, node, node_Refman)
+        CHECK_REF(305, node, node_Refman)
         LUMI_err = tl5_compiler_M_TypeInstance_can_be_assigned_to(node->item, node->item_Refman, type_instance, type_instance_Refman, &(aux_Bool_1));
-        CHECK(302)
+        CHECK(305)
         if (aux_Bool_1) {
             LUMI_err = tl5_compiler_M_TypeInstance_copy_new(type_instance, type_instance_Refman, &(new_type), &(new_type_Refman));
-            CHECK(304)
+            CHECK(307)
             aux_TypeInstance_0 = new_type;
             aux_TypeInstance_0_Refman = new_type_Refman;
             new_type = NULL;
             new_type_Refman = NULL;
-            CHECK_REF(305, node, node_Refman)
+            CHECK_REF(308, node, node_Refman)
             tl5_compiler_M_TypeInstance_Del(node->item);
             LUMI_owner_dec_ref(node->item_Refman);
             node->item_Refman = aux_TypeInstance_0_Refman;
@@ -33375,7 +33399,7 @@ Returncode tl5_compiler_M_DeleteGroup_add_specific_deleting_type(tl5_compiler_M_
             aux_TypeInstance_0_Refman = NULL;
             goto LUMI_cleanup;
         }
-        CHECK_REF(307, node, node_Refman)
+        CHECK_REF(310, node, node_Refman)
         aux_Ref_Manager = node_Refman;
         node_Refman = node->next_Refman;
         LUMI_inc_ref(node_Refman);
@@ -33383,11 +33407,11 @@ Returncode tl5_compiler_M_DeleteGroup_add_specific_deleting_type(tl5_compiler_M_
         aux_Ref_Manager = NULL;
         node = node->next;
     }
-    CHECK_REF(308, self, self_Refman)
+    CHECK_REF(311, self, self_Refman)
     LUMI_err = tl5_compiler_M_List_add(self->deleting_types, self->deleting_types_Refman, type_instance, type_instance_Refman, &tl5_compiler_M_TypeInstance_dynamic);
     type_instance = NULL;
     type_instance_Refman = NULL;
-    CHECK(308)
+    CHECK(311)
 LUMI_cleanup:
     tl5_compiler_M_TypeInstance_Del(aux_TypeInstance_0);
     LUMI_owner_dec_ref(aux_TypeInstance_0_Refman);
@@ -33408,11 +33432,11 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_DeleteGroup_set_delete_all(tl5_compiler_M_DeleteGroup* self, Ref_Manager* self_Refman) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(311, self, self_Refman)
+    CHECK_REF(314, self, self_Refman)
     self->delete_all = true;
-    CHECK_REF(312, self, self_Refman)
+    CHECK_REF(315, self, self_Refman)
     LUMI_err = tl5_compiler_M_List_clear(self->deleting_types, self->deleting_types_Refman);
-    CHECK(312)
+    CHECK(315)
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
     return LUMI_err;
@@ -33434,10 +33458,10 @@ Returncode tl5_compiler_M_FunctionCall_new(tl5_compiler_M_FunctionCall* self, Re
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(function_Refman);
     LUMI_inc_ref(calling_type_Refman);
-    CHECK_REF(320, self, self_Refman)
+    CHECK_REF(323, self, self_Refman)
     LUMI_err = tl5_compiler_M_TypeInstance_copy_new(calling_type, calling_type_Refman, &(self->calling_type), &(self->calling_type_Refman));
-    CHECK(320)
-    CHECK_REF(321, self, self_Refman)
+    CHECK(323)
+    CHECK_REF(324, self, self_Refman)
     aux_Ref_Manager = self->function_Refman;
     self->function_Refman = function_Refman;
     self->function_Dynamic = function_Dynamic;
@@ -33470,12 +33494,12 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_new(tl5_compiler_M_DeleteGroupBuild
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(owner_member_Refman);
-    INIT_NEW(331, aux_List_0, LUMI_alloc(sizeof(tl5_compiler_M_List)));
+    INIT_NEW(334, aux_List_0, LUMI_alloc(sizeof(tl5_compiler_M_List)));
     LUMI_err = tl5_compiler_M_DeleteGroup_new(&(self->_base), self_Refman, aux_List_0, aux_List_0_Refman, false);
     aux_List_0 = NULL;
     aux_List_0_Refman = NULL;
-    CHECK(331)
-    CHECK_REF(332, self, self_Refman)
+    CHECK(334)
+    CHECK_REF(335, self, self_Refman)
     aux_Ref_Manager = self->owner_member_Refman;
     self->owner_member_Refman = owner_member_Refman;
     self->owner_member_Dynamic = owner_member_Dynamic;
@@ -33483,12 +33507,12 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_new(tl5_compiler_M_DeleteGroupBuild
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     self->owner_member = owner_member;
-    CHECK_REF(333, self, self_Refman)
-    CHECK_REF(333, self, self_Refman)
-    CHECK_REF(333, self->owner_member, self->owner_member_Refman)
-    CHECK_REF(333, self, self_Refman)
+    CHECK_REF(336, self, self_Refman)
+    CHECK_REF(336, self, self_Refman)
+    CHECK_REF(336, self->owner_member, self->owner_member_Refman)
+    CHECK_REF(336, self, self_Refman)
     LUMI_err = tl5_compiler_M_NameMap_add(&(self->members), self_Refman, self->owner_member->name, self->owner_member->name_Refman, self->owner_member, self->owner_member_Refman, (void*)self->owner_member_Dynamic);
-    CHECK(333)
+    CHECK(336)
 LUMI_cleanup:
     tl5_compiler_M_List_Del(aux_List_0);
     LUMI_owner_dec_ref(aux_List_0_Refman);
@@ -33508,14 +33532,14 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_add_calling(tl5_compiler_M_DeleteGr
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(function_Refman);
     LUMI_inc_ref(calling_type_Refman);
-    CHECK_REF(337, self, self_Refman)
-    INIT_NEW(338, aux_FunctionCall_0, LUMI_alloc(sizeof(tl5_compiler_M_FunctionCall)));
+    CHECK_REF(340, self, self_Refman)
+    INIT_NEW(341, aux_FunctionCall_0, LUMI_alloc(sizeof(tl5_compiler_M_FunctionCall)));
     LUMI_err = tl5_compiler_M_FunctionCall_new(aux_FunctionCall_0, aux_FunctionCall_0_Refman, function, function_Refman, function_Dynamic, calling_type, calling_type_Refman);
-    CHECK(337)
+    CHECK(340)
     LUMI_err = tl5_compiler_M_List_add(&(self->calling_functions), self_Refman, aux_FunctionCall_0, aux_FunctionCall_0_Refman, &tl5_compiler_M_FunctionCall_dynamic);
     aux_FunctionCall_0 = NULL;
     aux_FunctionCall_0_Refman = NULL;
-    CHECK(337)
+    CHECK(340)
 LUMI_cleanup:
     tl5_compiler_M_FunctionCall_Del(aux_FunctionCall_0);
     LUMI_owner_dec_ref(aux_FunctionCall_0_Refman);
@@ -33539,8 +33563,8 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_add_dynamic_override(tl5_compiler_M
     LUMI_inc_ref(type_data_Refman);
     LUMI_inc_ref(overwriting_Refman);
     LUMI_inc_ref(overridden_Refman);
-    INIT_VAR(344, calling_type)
-    CHECK_REF(345, calling_type, calling_type_Refman)
+    INIT_VAR(347, calling_type)
+    CHECK_REF(348, calling_type, calling_type_Refman)
     aux_Ref_Manager = calling_type->type_data_Refman;
     calling_type->type_data_Refman = type_data_Refman;
     calling_type->type_data_Dynamic = type_data_Dynamic;
@@ -33548,17 +33572,17 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_add_dynamic_override(tl5_compiler_M
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     calling_type->type_data = type_data;
-    CHECK_REF(346, type_data, type_data_Refman)
-    CHECK_REF(346, calling_type, calling_type_Refman)
+    CHECK_REF(349, type_data, type_data_Refman)
+    CHECK_REF(349, calling_type, calling_type_Refman)
     LUMI_err = tl5_compiler_M_string_new_copy(type_data->name, type_data->name_Refman, &(calling_type->name), &(calling_type->name_Refman));
-    CHECK(346)
-    CHECK_REF(347, type_data, type_data_Refman)
+    CHECK(349)
+    CHECK_REF(350, type_data, type_data_Refman)
     if (type_data->parameters != NULL && type_data->parameters_Refman->value != NULL) {
         LUMI_err = tl5_compiler_M_DeleteGroup_set_delete_all(&(self->_base), self_Refman);
-        CHECK(348)
+        CHECK(351)
     }
     LUMI_err = tl5_compiler_M_DeleteGroupBuilder_add_calling(self, self_Refman, overwriting, overwriting_Refman, overwriting_Dynamic, calling_type, calling_type_Refman);
-    CHECK(349)
+    CHECK(352)
 LUMI_cleanup:
     LUMI_var_dec_ref(calling_type_Refman);
     LUMI_dec_ref(overridden_Refman);
@@ -33578,7 +33602,7 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_build(tl5_compiler_M_DeleteGroupBui
     Ref_Manager* call_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(352, self, self_Refman)
+    CHECK_REF(355, self, self_Refman)
     if (self->working) {
         aux_Ref_Manager = *recursive_Refman;
         *recursive_Refman = self_Refman;
@@ -33588,16 +33612,16 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_build(tl5_compiler_M_DeleteGroupBui
         *recursive = self;
         goto LUMI_cleanup;
     }
-    CHECK_REF(355, self, self_Refman)
+    CHECK_REF(358, self, self_Refman)
     self->working = true;
     while (true) {
-        CHECK_REF(358, self, self_Refman)
+        CHECK_REF(361, self, self_Refman)
         LUMI_err = tl5_compiler_M_List_pop(&(self->calling_functions), self_Refman, (void*)&(call), &(call_Refman), &dynamic_Void);
-        CHECK(358)
+        CHECK(361)
         if (!(call != NULL && call_Refman->value != NULL)) break;
-        CHECK_REF(359, call, call_Refman)
+        CHECK_REF(362, call, call_Refman)
         LUMI_err = tl5_compiler_M_SyntaxTreeFunction_collect_delete_group(call->function, call->function_Refman, call->function_Dynamic, &(*recursive), &(*recursive_Refman));
-        CHECK(359)
+        CHECK(362)
         if ((*recursive) != NULL && (*recursive_Refman)->value != NULL) {
             if ((void*)(*recursive) == self) {
                 aux_Ref_Manager = *recursive_Refman;
@@ -33609,16 +33633,16 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_build(tl5_compiler_M_DeleteGroupBui
                 continue;
             }
             LUMI_err = tl5_compiler_M_DeleteGroupBuilder_merge_from(*recursive, *recursive_Refman, self, self_Refman);
-            CHECK(363)
+            CHECK(366)
             goto LUMI_cleanup;
         }
         LUMI_err = tl5_compiler_M_DeleteGroupBuilder_extend_call(self, self_Refman, call, call_Refman);
         call = NULL;
         call_Refman = NULL;
-        CHECK(365)
+        CHECK(368)
     }
     LUMI_err = tl5_compiler_M_DeleteGroupBuilder_done(self, self_Refman);
-    CHECK(366)
+    CHECK(369)
 LUMI_cleanup:
     tl5_compiler_M_FunctionCall_Del(call);
     LUMI_owner_dec_ref(call_Refman);
@@ -33640,23 +33664,23 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_extend_call(tl5_compiler_M_DeleteGr
     Ref_Manager* aux_ListIterator_1_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(369, self, self_Refman)
+    CHECK_REF(372, self, self_Refman)
     if (self->_base.delete_all) {
-        goto LUMI_cleanup;
-    }
-    CHECK_REF(371, call, call_Refman)
-    CHECK_REF(371, call->function, call->function_Refman)
-    CHECK_REF(371, call->function->delete_group, call->function->delete_group_Refman)
-    if (call->function->delete_group->delete_all) {
-        LUMI_err = tl5_compiler_M_DeleteGroup_set_delete_all(&(self->_base), self_Refman);
-        CHECK(372)
         goto LUMI_cleanup;
     }
     CHECK_REF(374, call, call_Refman)
     CHECK_REF(374, call->function, call->function_Refman)
     CHECK_REF(374, call->function->delete_group, call->function->delete_group_Refman)
+    if (call->function->delete_group->delete_all) {
+        LUMI_err = tl5_compiler_M_DeleteGroup_set_delete_all(&(self->_base), self_Refman);
+        CHECK(375)
+        goto LUMI_cleanup;
+    }
+    CHECK_REF(377, call, call_Refman)
+    CHECK_REF(377, call->function, call->function_Refman)
+    CHECK_REF(377, call->function->delete_group, call->function->delete_group_Refman)
     LUMI_err = tl5_compiler_M_List_iter(call->function->delete_group->deleting_types, call->function->delete_group->deleting_types_Refman, &(aux_ListIterator_0), &(aux_ListIterator_0_Refman));
-    CHECK(374)
+    CHECK(377)
     aux_Ref_Manager = aux_ListIterator_1_Refman;
     aux_ListIterator_1_Refman = aux_ListIterator_0_Refman;
     LUMI_inc_ref(aux_ListIterator_1_Refman);
@@ -33666,17 +33690,17 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_extend_call(tl5_compiler_M_DeleteGr
     while (true) {
         Bool type_instance_Has = false;
         LUMI_err = tl5_compiler_M_ListIterator_has(aux_ListIterator_1, aux_ListIterator_1_Refman, &(type_instance_Has));
-        CHECK(374)
+        CHECK(377)
         if (!type_instance_Has) break;
         LUMI_err = tl5_compiler_M_ListIterator_get(aux_ListIterator_1, aux_ListIterator_1_Refman, (void*)&(type_instance), &(type_instance_Refman), &dynamic_Void);
-        CHECK(374)
-        CHECK_REF(376, call, call_Refman)
-        LUMI_err = tl5_compiler_M_TypeInstance_replace_type_parameters(type_instance, type_instance_Refman, call->calling_type, call->calling_type_Refman, true);
-        CHECK(375)
-        LUMI_err = tl5_compiler_M_DeleteGroup_add_deleting(&(self->_base), self_Refman, type_instance, type_instance_Refman);
         CHECK(377)
+        CHECK_REF(379, call, call_Refman)
+        LUMI_err = tl5_compiler_M_TypeInstance_replace_type_parameters(type_instance, type_instance_Refman, call->calling_type, call->calling_type_Refman, true);
+        CHECK(378)
+        LUMI_err = tl5_compiler_M_DeleteGroup_add_deleting(&(self->_base), self_Refman, type_instance, type_instance_Refman);
+        CHECK(380)
         LUMI_err = tl5_compiler_M_ListIterator_next(aux_ListIterator_1, aux_ListIterator_1_Refman);
-        CHECK(374)
+        CHECK(377)
     }
     aux_Ref_Manager = aux_ListIterator_1_Refman;
     aux_ListIterator_1_Refman = NULL;
@@ -33709,28 +33733,28 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_merge_from(tl5_compiler_M_DeleteGro
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(other_Refman);
-    CHECK_REF(380, other, other_Refman)
+    CHECK_REF(383, other, other_Refman)
     if (other->_base.delete_all) {
         LUMI_err = tl5_compiler_M_DeleteGroup_set_delete_all(&(self->_base), self_Refman);
-        CHECK(381)
+        CHECK(384)
     }
     else {
-            CHECK_REF(382, self, self_Refman)
+            CHECK_REF(385, self, self_Refman)
             if (! self->_base.delete_all) {
                 LUMI_err = tl5_compiler_M_DeleteGroup_extend(&(self->_base), self_Refman, &(other->_base), other_Refman);
-                CHECK(383)
+                CHECK(386)
             }
         }
     while (true) {
-        CHECK_REF(386, other, other_Refman)
+        CHECK_REF(389, other, other_Refman)
         LUMI_err = tl5_compiler_M_NameMap_pop(&(other->members), other_Refman, (void*)&(function), &(function_Refman), (void*)&(function_Dynamic));
-        CHECK(386)
+        CHECK(389)
         if (!(function != NULL && function_Refman->value != NULL)) break;
-        CHECK_REF(387, self, self_Refman)
-        CHECK_REF(387, function, function_Refman)
+        CHECK_REF(390, self, self_Refman)
+        CHECK_REF(390, function, function_Refman)
         LUMI_err = tl5_compiler_M_NameMap_add(&(self->members), self_Refman, function->name, function->name_Refman, function, function_Refman, (void*)function_Dynamic);
-        CHECK(387)
-        CHECK_REF(388, function, function_Refman)
+        CHECK(390)
+        CHECK_REF(391, function, function_Refman)
         aux_Ref_Manager = function->delete_group_builder_Refman;
         function->delete_group_builder_Refman = self_Refman;
         LUMI_inc_ref(function->delete_group_builder_Refman);
@@ -33739,18 +33763,18 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_merge_from(tl5_compiler_M_DeleteGro
         function->delete_group_builder = self;
     }
     while (true) {
-        CHECK_REF(391, other, other_Refman)
+        CHECK_REF(394, other, other_Refman)
         LUMI_err = tl5_compiler_M_List_pop(&(other->calling_functions), other_Refman, (void*)&(call), &(call_Refman), &dynamic_Void);
-        CHECK(391)
+        CHECK(394)
         if (!(call != NULL && call_Refman->value != NULL)) break;
-        CHECK_REF(392, self, self_Refman)
+        CHECK_REF(395, self, self_Refman)
         LUMI_err = tl5_compiler_M_List_add(&(self->calling_functions), self_Refman, call, call_Refman, &tl5_compiler_M_FunctionCall_dynamic);
         call = NULL;
         call_Refman = NULL;
-        CHECK(392)
+        CHECK(395)
     }
     LUMI_err = tl5_compiler_M_DeleteGroupBuilder_kill(other, other_Refman);
-    CHECK(393)
+    CHECK(396)
 LUMI_cleanup:
     tl5_compiler_M_FunctionCall_Del(call);
     LUMI_owner_dec_ref(call_Refman);
@@ -33779,28 +33803,28 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_done(tl5_compiler_M_DeleteGroupBuil
     Ref_Manager* aux_NameMapIterator_1_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(397, self, self_Refman)
-    CHECK_REF(397, self, self_Refman)
-    INIT_NEW(396, aux_DeleteGroup_0, LUMI_alloc(sizeof(tl5_compiler_M_DeleteGroup)));
+    CHECK_REF(400, self, self_Refman)
+    CHECK_REF(400, self, self_Refman)
+    INIT_NEW(399, aux_DeleteGroup_0, LUMI_alloc(sizeof(tl5_compiler_M_DeleteGroup)));
     LUMI_err = tl5_compiler_M_DeleteGroup_new(aux_DeleteGroup_0, aux_DeleteGroup_0_Refman, self->_base.deleting_types, self->_base.deleting_types_Refman, self->_base.delete_all);
     self->_base.deleting_types = NULL;
     self->_base.deleting_types_Refman = NULL;
-    CHECK(396)
+    CHECK(399)
     aux_DeleteGroup_1 = aux_DeleteGroup_0;
     aux_DeleteGroup_1_Refman = aux_DeleteGroup_0_Refman;
     aux_DeleteGroup_0 = NULL;
     aux_DeleteGroup_0_Refman = NULL;
-    CHECK_REF(396, self, self_Refman)
-    CHECK_REF(396, self->owner_member, self->owner_member_Refman)
+    CHECK_REF(399, self, self_Refman)
+    CHECK_REF(399, self->owner_member, self->owner_member_Refman)
     tl5_compiler_M_DeleteGroup_Del(self->owner_member->delete_group_owner);
     LUMI_owner_dec_ref(self->owner_member->delete_group_owner_Refman);
     self->owner_member->delete_group_owner_Refman = aux_DeleteGroup_1_Refman;
     self->owner_member->delete_group_owner = aux_DeleteGroup_1;
     aux_DeleteGroup_1 = NULL;
     aux_DeleteGroup_1_Refman = NULL;
-    CHECK_REF(398, self, self_Refman)
+    CHECK_REF(401, self, self_Refman)
     LUMI_err = tl5_compiler_M_NameMap_iter(&(self->members), self_Refman, &(aux_NameMapIterator_0), &(aux_NameMapIterator_0_Refman));
-    CHECK(398)
+    CHECK(401)
     aux_Ref_Manager = aux_NameMapIterator_1_Refman;
     aux_NameMapIterator_1_Refman = aux_NameMapIterator_0_Refman;
     LUMI_inc_ref(aux_NameMapIterator_1_Refman);
@@ -33810,20 +33834,20 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_done(tl5_compiler_M_DeleteGroupBuil
     while (true) {
         Bool member_Has = false;
         LUMI_err = tl5_compiler_M_NameMapIterator_has(aux_NameMapIterator_1, aux_NameMapIterator_1_Refman, &(member_Has));
-        CHECK(398)
+        CHECK(401)
         if (!member_Has) break;
         LUMI_err = tl5_compiler_M_NameMapIterator_get(aux_NameMapIterator_1, aux_NameMapIterator_1_Refman, (void*)&(member), &(member_Refman), (void*)&(member_Dynamic));
-        CHECK(398)
-        CHECK_REF(399, self, self_Refman)
-        CHECK_REF(399, self->owner_member, self->owner_member_Refman)
-        CHECK_REF(399, member, member_Refman)
+        CHECK(401)
+        CHECK_REF(402, self, self_Refman)
+        CHECK_REF(402, self->owner_member, self->owner_member_Refman)
+        CHECK_REF(402, member, member_Refman)
         aux_Ref_Manager = member->delete_group_Refman;
         member->delete_group_Refman = self->owner_member->delete_group_owner_Refman;
         LUMI_inc_ref(member->delete_group_Refman);
         LUMI_dec_ref(aux_Ref_Manager);
         aux_Ref_Manager = NULL;
         member->delete_group = self->owner_member->delete_group_owner;
-        CHECK_REF(400, member, member_Refman)
+        CHECK_REF(403, member, member_Refman)
         aux_Ref_Manager = member->delete_group_builder_Refman;
         member->delete_group_builder_Refman = NULL;
         LUMI_inc_ref(member->delete_group_builder_Refman);
@@ -33831,7 +33855,7 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_done(tl5_compiler_M_DeleteGroupBuil
         aux_Ref_Manager = NULL;
         member->delete_group_builder = NULL;
         LUMI_err = tl5_compiler_M_NameMapIterator_next(aux_NameMapIterator_1, aux_NameMapIterator_1_Refman);
-        CHECK(398)
+        CHECK(401)
     }
     aux_Ref_Manager = aux_NameMapIterator_1_Refman;
     aux_NameMapIterator_1_Refman = NULL;
@@ -33839,10 +33863,10 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_done(tl5_compiler_M_DeleteGroupBuil
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     aux_NameMapIterator_1 = NULL;
-    CHECK_REF(401, self, self_Refman)
+    CHECK_REF(404, self, self_Refman)
     self->working = false;
     LUMI_err = tl5_compiler_M_DeleteGroupBuilder_kill(self, self_Refman);
-    CHECK(402)
+    CHECK(405)
 LUMI_cleanup:
     LUMI_dec_ref(aux_NameMapIterator_1_Refman);
     LUMI_dec_ref(member_Refman);
@@ -33867,8 +33891,8 @@ Returncode tl5_compiler_M_DeleteGroupBuilder_kill(tl5_compiler_M_DeleteGroupBuil
     LUMI_inc_ref(self_Refman);
     aux_DeleteGroupBuilder_0 = NULL;
     aux_DeleteGroupBuilder_0_Refman = NULL;
-    CHECK_REF(405, self, self_Refman)
-    CHECK_REF(405, self->owner_member, self->owner_member_Refman)
+    CHECK_REF(408, self, self_Refman)
+    CHECK_REF(408, self->owner_member, self->owner_member_Refman)
     tl5_compiler_M_DeleteGroupBuilder_Del(self->owner_member->delete_group_builder_owner);
     LUMI_owner_dec_ref(self->owner_member->delete_group_builder_owner_Refman);
     self->owner_member->delete_group_builder_owner_Refman = aux_DeleteGroupBuilder_0_Refman;
@@ -49669,9 +49693,9 @@ Returncode tl5_compiler_M_swap_operator_factory(tl5_compiler_M_SyntaxTreeCode* c
     tl5_compiler_M_BinaryExpression_Dynamic* aux_BinaryExpression_0_Dynamic = NULL;
     LUMI_inc_ref(code_node_Refman);
     LUMI_inc_ref(operator_Refman);
-    INIT_NEW(336, aux_SwapOperatorExpression_0, LUMI_alloc(sizeof(tl5_compiler_M_SwapOperatorExpression)));
+    INIT_NEW(339, aux_SwapOperatorExpression_0, LUMI_alloc(sizeof(tl5_compiler_M_SwapOperatorExpression)));
     LUMI_err = tl5_compiler_M_UnaryExpression_new(&(aux_SwapOperatorExpression_0->_base._base), aux_SwapOperatorExpression_0_Refman, &(aux_SwapOperatorExpression_0_Dynamic->_base._base), code_node, code_node_Refman, code_node_Dynamic, operator, operator_Refman);
-    CHECK(336)
+    CHECK(339)
     aux_BinaryExpression_0 = &(aux_SwapOperatorExpression_0->_base);
     aux_BinaryExpression_0_Refman = aux_SwapOperatorExpression_0_Refman;
     aux_BinaryExpression_0_Dynamic = &(aux_SwapOperatorExpression_0_Dynamic->_base);
@@ -49707,10 +49731,10 @@ Returncode tl5_compiler_M_unary_operator_factory(tl5_compiler_M_SyntaxTreeCode* 
     Ref_Manager* aux_String_0_Refman = NULL;
     LUMI_inc_ref(code_node_Refman);
     LUMI_inc_ref(operator_Refman);
-    INIT_STRING_CONST(342, aux_String_0, "used non-binary operator");
-    CHECK_REF(342, operator, operator_Refman)
+    INIT_STRING_CONST(345, aux_String_0, "used non-binary operator");
+    CHECK_REF(345, operator, operator_Refman)
     LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(code_node->_base), code_node_Refman, &(code_node_Dynamic->_base), aux_String_0, aux_String_0_Refman, operator->name, operator->name_Refman);
-    CHECK(342)
+    CHECK(345)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_0_Refman);
     LUMI_dec_ref(operator_Refman);

--- a/TL5/tl5-compiler.c
+++ b/TL5/tl5-compiler.c
@@ -7040,6 +7040,9 @@ Returncode tl5_compiler_M_AssignExpression_check_operands_memory(tl5_compiler_M_
     Bool is_forward_move = 0;
     Bool aux_Bool_0 = 0;
     Bool aux_Bool_1 = 0;
+    String aux_String_0_Var = {0};
+    String* aux_String_0 = NULL;
+    Ref_Manager* aux_String_0_Refman = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(refs_Refman);
     CHECK_REF(50, self, self_Refman)
@@ -7077,33 +7080,47 @@ Returncode tl5_compiler_M_AssignExpression_check_operands_memory(tl5_compiler_M_
         CHECK_REF(61, self, self_Refman)
         LUMI_err = tl5_compiler_M_ReferenceMemoryList_check_writing_memory(refs, refs_Refman, self->value, self->value_Refman, self->value_Dynamic);
         CHECK(61)
+        CHECK_REF(62, self, self_Refman)
+        CHECK_REF(62, self->target, self->target_Refman)
+        if ((self->target->access == tl5_compiler_M_Access_TEMP) && (value_path != NULL && value_path_Refman->value != NULL)) {
+            CHECK_REF(63, value_path, value_path_Refman)
+            CHECK_REF(63, value_path->variable, value_path->variable_Refman)
+            if (! (value_path->variable->_base.parent != NULL && value_path->variable->_base.parent_Refman->value != NULL)) {
+                INIT_STRING_CONST(65, aux_String_0, "cannot take temporary owner from global");
+                CHECK_REF(66, value_path, value_path_Refman)
+                CHECK_REF(66, value_path->variable, value_path->variable_Refman)
+                LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_0, aux_String_0_Refman, value_path->variable->name, value_path->variable->name_Refman);
+                CHECK(64)
+            }
+        }
         if (! is_forward_move) {
-            CHECK_REF(63, self, self_Refman)
-            CHECK_REF(63, self->target, self->target_Refman)
+            CHECK_REF(68, self, self_Refman)
+            CHECK_REF(68, self->target, self->target_Refman)
             if (self->target->access == tl5_compiler_M_Access_TEMP) {
                 LUMI_err = tl5_compiler_M_ReferenceMemoryList_mark_full_path_block_invalid(refs, refs_Refman, value_path, value_path_Refman);
-                CHECK(64)
+                CHECK(69)
             }
             else {
                     LUMI_err = tl5_compiler_M_ReferenceMemoryList_mark_invalid_reference(refs, refs_Refman, value_path, value_path_Refman);
-                    CHECK(66)
+                    CHECK(71)
                 }
-            CHECK_REF(67, self, self_Refman)
+            CHECK_REF(72, self, self_Refman)
             LUMI_err = tl5_compiler_M_ReferenceMemoryList_check_writing_memory(refs, refs_Refman, self->target, self->target_Refman, self->target_Dynamic);
-            CHECK(67)
+            CHECK(72)
         }
     }
     else {
-            CHECK_REF(69, self, self_Refman)
-            if (self->value_Dynamic == NULL) RAISE(69, empty_object)
+            CHECK_REF(74, self, self_Refman)
+            if (self->value_Dynamic == NULL) RAISE(74, empty_object)
             LUMI_err = self->value_Dynamic->_base.check_memory(&(self->value->_base), self->value_Refman, &(self->value_Dynamic->_base), refs, refs_Refman);
-            CHECK(69)
-            CHECK_REF(70, self, self_Refman)
-            if (self->target_Dynamic == NULL) RAISE(70, empty_object)
+            CHECK(74)
+            CHECK_REF(75, self, self_Refman)
+            if (self->target_Dynamic == NULL) RAISE(75, empty_object)
             LUMI_err = self->target_Dynamic->_base.check_memory(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base), refs, refs_Refman);
-            CHECK(70)
+            CHECK(75)
         }
 LUMI_cleanup:
+    LUMI_var_dec_ref(aux_String_0_Refman);
     LUMI_dec_ref(value_path_Refman);
     LUMI_dec_ref(target_path_Refman);
     LUMI_dec_ref(refs_Refman);
@@ -7126,50 +7143,50 @@ Returncode tl5_compiler_M_AssignExpression_check_forward_move(tl5_compiler_M_Ass
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
     *res = false;
-    CHECK_REF(75, self, self_Refman)
-    CHECK_REF(75, self->target, self->target_Refman)
-    CHECK_REF(75, self->target->result_type, self->target->result_type_Refman)
+    CHECK_REF(80, self, self_Refman)
+    CHECK_REF(80, self->target, self->target_Refman)
+    CHECK_REF(80, self->target->result_type, self->target->result_type_Refman)
     target_path = self->target->result_type->reference_path;
     target_path_Refman = self->target->result_type->reference_path_Refman;
     LUMI_inc_ref(target_path_Refman);
-    CHECK_REF(77, self, self_Refman)
-    CHECK_REF(77, self->value, self->value_Refman)
-    CHECK_REF(77, self->value->result_type, self->value->result_type_Refman)
+    CHECK_REF(82, self, self_Refman)
+    CHECK_REF(82, self->value, self->value_Refman)
+    CHECK_REF(82, self->value->result_type, self->value->result_type_Refman)
     value_path = self->value->result_type->reference_path;
     value_path_Refman = self->value->result_type->reference_path_Refman;
     LUMI_inc_ref(value_path_Refman);
     if ((! (target_path != NULL && target_path_Refman->value != NULL)) || (! (value_path != NULL && value_path_Refman->value != NULL))) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(81, self, self_Refman)
-    CHECK_REF(81, self->target, self->target_Refman)
-    CHECK_REF(80, self, self_Refman)
-    CHECK_REF(80, self->target, self->target_Refman)
+    CHECK_REF(86, self, self_Refman)
+    CHECK_REF(86, self->target, self->target_Refman)
+    CHECK_REF(85, self, self_Refman)
+    CHECK_REF(85, self->target, self->target_Refman)
     LUMI_err = tl5_compiler_M_access_is_owner(self->target->access, &(aux_Bool_0));
-    CHECK(80)
+    CHECK(85)
     if ((! aux_Bool_0) && (! (self->target->access == tl5_compiler_M_Access_TEMP))) {
         goto LUMI_cleanup;
     }
     while (true) {
-        CHECK_REF(84, value_path, value_path_Refman)
-        CHECK_REF(84, target_path, target_path_Refman)
+        CHECK_REF(89, value_path, value_path_Refman)
+        CHECK_REF(89, target_path, target_path_Refman)
         if ((void*)target_path->variable != value_path->variable) {
             goto LUMI_cleanup;
         }
-        CHECK_REF(86, value_path, value_path_Refman)
+        CHECK_REF(91, value_path, value_path_Refman)
         if (! (value_path->field != NULL && value_path->field_Refman->value != NULL)) {
             goto LUMI_cleanup;
         }
-        CHECK_REF(88, target_path, target_path_Refman)
+        CHECK_REF(93, target_path, target_path_Refman)
         if (!(target_path->field != NULL && target_path->field_Refman->value != NULL)) break;
-        CHECK_REF(89, target_path, target_path_Refman)
+        CHECK_REF(94, target_path, target_path_Refman)
         aux_Ref_Manager = target_path_Refman;
         target_path_Refman = target_path->field_Refman;
         LUMI_inc_ref(target_path_Refman);
         LUMI_dec_ref(aux_Ref_Manager);
         aux_Ref_Manager = NULL;
         target_path = target_path->field;
-        CHECK_REF(90, value_path, value_path_Refman)
+        CHECK_REF(95, value_path, value_path_Refman)
         aux_Ref_Manager = value_path_Refman;
         value_path_Refman = value_path->field_Refman;
         LUMI_inc_ref(value_path_Refman);
@@ -7177,19 +7194,19 @@ Returncode tl5_compiler_M_AssignExpression_check_forward_move(tl5_compiler_M_Ass
         aux_Ref_Manager = NULL;
         value_path = value_path->field;
     }
-    CHECK_REF(91, self, self_Refman)
-    CHECK_REF(91, self->target, self->target_Refman)
+    CHECK_REF(96, self, self_Refman)
+    CHECK_REF(96, self->target, self->target_Refman)
     LUMI_err = tl5_compiler_M_access_is_owner(self->target->access, &(aux_Bool_1));
-    CHECK(91)
+    CHECK(96)
     if (aux_Bool_1) {
-        CHECK_REF(92, self, self_Refman)
-        CHECK_REF(93, self, self_Refman)
-        CHECK_REF(93, self->value, self->value_Refman)
-        CHECK_REF(95, self, self_Refman)
-        CHECK_REF(95, self->target, self->target_Refman)
-        CHECK_REF(96, self, self_Refman)
+        CHECK_REF(97, self, self_Refman)
+        CHECK_REF(98, self, self_Refman)
+        CHECK_REF(98, self->value, self->value_Refman)
+        CHECK_REF(100, self, self_Refman)
+        CHECK_REF(100, self->target, self->target_Refman)
+        CHECK_REF(101, self, self_Refman)
         LUMI_err = tl5_compiler_M_SyntaxTreeCode_add_aux_variable(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic, self->value->access, false, self->target->result_type, self->target->result_type_Refman, &(self->aux_variable), &(self->aux_variable_Refman), &(self->aux_variable_Dynamic));
-        CHECK(92)
+        CHECK(97)
     }
     *res = true;
 LUMI_cleanup:
@@ -7207,24 +7224,24 @@ Returncode tl5_compiler_M_AssignExpression_write_preactions(tl5_compiler_M_Assig
     Returncode LUMI_err = OK;
     Bool aux_Bool_0 = 0;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(100, self, self_Refman)
-    if (self->value_Dynamic == NULL) RAISE(100, empty_object)
+    CHECK_REF(105, self, self_Refman)
+    if (self->value_Dynamic == NULL) RAISE(105, empty_object)
     LUMI_err = self->value_Dynamic->write_preactions(self->value, self->value_Refman, self->value_Dynamic);
-    CHECK(100)
-    CHECK_REF(101, self, self_Refman)
-    if (self->target_Dynamic == NULL) RAISE(101, empty_object)
+    CHECK(105)
+    CHECK_REF(106, self, self_Refman)
+    if (self->target_Dynamic == NULL) RAISE(106, empty_object)
     LUMI_err = self->target_Dynamic->write_preactions(self->target, self->target_Refman, self->target_Dynamic);
-    CHECK(101)
-    CHECK_REF(102, self, self_Refman)
-    CHECK_REF(102, self->target, self->target_Refman)
+    CHECK(106)
+    CHECK_REF(107, self, self_Refman)
+    CHECK_REF(107, self->target, self->target_Refman)
     LUMI_err = tl5_compiler_M_access_is_owner(self->target->access, &(aux_Bool_0));
-    CHECK(102)
+    CHECK(107)
     if (aux_Bool_0) {
         LUMI_err = tl5_compiler_M_AssignExpression_write_owner_assign_preactions(self, self_Refman, self_Dynamic);
-        CHECK(103)
+        CHECK(108)
     }
     LUMI_err = tl5_compiler_M_AssignExpression_write_assign_preactions(self, self_Refman, self_Dynamic, true);
-    CHECK(104)
+    CHECK(109)
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
     return LUMI_err;
@@ -7239,44 +7256,44 @@ Returncode tl5_compiler_M_AssignExpression_write_assign_preactions(tl5_compiler_
     Bool aux_Bool_0 = 0;
     Bool aux_Bool_1 = 0;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(108, self, self_Refman)
-    CHECK_REF(108, self->value, self->value_Refman)
+    CHECK_REF(113, self, self_Refman)
+    CHECK_REF(113, self->value, self->value_Refman)
     LUMI_err = tl5_compiler_M_access_has_refman(self->value->access, &(aux_Bool_0));
-    CHECK(107)
-    CHECK_REF(107, self, self_Refman)
-    CHECK_REF(107, self->target, self->target_Refman)
+    CHECK(112)
+    CHECK_REF(112, self, self_Refman)
+    CHECK_REF(112, self->target, self->target_Refman)
     LUMI_err = tl5_compiler_M_access_has_refman(self->target->access, &(aux_Bool_1));
-    CHECK(107)
+    CHECK(112)
     if (aux_Bool_1 && aux_Bool_0) {
         LUMI_err = tl5_compiler_M_AssignExpression_write_assign_refman(self, self_Refman, self_Dynamic, full_assign);
-        CHECK(109)
-    }
-    CHECK_REF(111, self, self_Refman)
-    CHECK_REF(111, self->target, self->target_Refman)
-    CHECK_REF(110, self, self_Refman)
-    CHECK_REF(110, self->target, self->target_Refman)
-    CHECK_REF(110, self->target->result_type, self->target->result_type_Refman)
-    CHECK_REF(110, self->target->result_type->type_data, self->target->result_type->type_data_Refman)
-    if (self->target->result_type->type_data->is_dynamic || self->target->is_generic_cast) {
-        LUMI_err = tl5_compiler_M_AssignExpression_write_assign_dynamic(self, self_Refman, self_Dynamic);
-        CHECK(112)
-    }
-    CHECK_REF(113, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(113, self, self_Refman)
-    CHECK_REF(113, self->target, self->target_Refman)
-    CHECK_REF(113, self->target->result_type, self->target->result_type_Refman)
-    if ((void*)self->target->result_type->type_data == tl5_compiler_M_glob->type_array) {
-        LUMI_err = tl5_compiler_M_AssignExpression_write_array_preactions(self, self_Refman, self_Dynamic);
         CHECK(114)
     }
+    CHECK_REF(116, self, self_Refman)
+    CHECK_REF(116, self->target, self->target_Refman)
+    CHECK_REF(115, self, self_Refman)
+    CHECK_REF(115, self->target, self->target_Refman)
+    CHECK_REF(115, self->target->result_type, self->target->result_type_Refman)
+    CHECK_REF(115, self->target->result_type->type_data, self->target->result_type->type_data_Refman)
+    if (self->target->result_type->type_data->is_dynamic || self->target->is_generic_cast) {
+        LUMI_err = tl5_compiler_M_AssignExpression_write_assign_dynamic(self, self_Refman, self_Dynamic);
+        CHECK(117)
+    }
+    CHECK_REF(118, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(118, self, self_Refman)
+    CHECK_REF(118, self->target, self->target_Refman)
+    CHECK_REF(118, self->target->result_type, self->target->result_type_Refman)
+    if ((void*)self->target->result_type->type_data == tl5_compiler_M_glob->type_array) {
+        LUMI_err = tl5_compiler_M_AssignExpression_write_array_preactions(self, self_Refman, self_Dynamic);
+        CHECK(119)
+    }
     else {
-            CHECK_REF(115, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-            CHECK_REF(115, self, self_Refman)
-            CHECK_REF(115, self->target, self->target_Refman)
-            CHECK_REF(115, self->target->result_type, self->target->result_type_Refman)
+            CHECK_REF(120, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+            CHECK_REF(120, self, self_Refman)
+            CHECK_REF(120, self->target, self->target_Refman)
+            CHECK_REF(120, self->target->result_type, self->target->result_type_Refman)
             if ((void*)self->target->result_type->type_data == tl5_compiler_M_glob->type_string) {
                 LUMI_err = tl5_compiler_M_AssignExpression_write_string_preactions(self, self_Refman, self_Dynamic);
-                CHECK(116)
+                CHECK(121)
             }
         }
 LUMI_cleanup:
@@ -7339,67 +7356,67 @@ Returncode tl5_compiler_M_AssignExpression_write_array_preactions(tl5_compiler_M
     Ref_Manager* aux_String_12_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(119, self, self_Refman)
-    if (self->target_Dynamic == NULL) RAISE(119, empty_object)
+    CHECK_REF(124, self, self_Refman)
+    if (self->target_Dynamic == NULL) RAISE(124, empty_object)
     LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
-    CHECK(119)
-    INIT_STRING_CONST(120, aux_String_0, "_Length = ");
+    CHECK(124)
+    INIT_STRING_CONST(125, aux_String_0, "_Length = ");
     LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(120)
-    CHECK_REF(121, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(121, self, self_Refman)
-    CHECK_REF(121, self->value, self->value_Refman)
-    CHECK_REF(121, self->value->result_type, self->value->result_type_Refman)
+    CHECK(125)
+    CHECK_REF(126, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(126, self, self_Refman)
+    CHECK_REF(126, self->value, self->value_Refman)
+    CHECK_REF(126, self->value->result_type, self->value->result_type_Refman)
     if ((void*)self->value->result_type->type_data == tl5_compiler_M_glob->type_string) {
-        INIT_STRING_CONST(122, aux_String_1, "*(");
+        INIT_STRING_CONST(127, aux_String_1, "*(");
         LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-        CHECK(122)
-        CHECK_REF(123, self, self_Refman)
-        if (self->value_Dynamic == NULL) RAISE(123, empty_object)
+        CHECK(127)
+        CHECK_REF(128, self, self_Refman)
+        if (self->value_Dynamic == NULL) RAISE(128, empty_object)
         LUMI_err = self->value_Dynamic->_base.write(&(self->value->_base), self->value_Refman, &(self->value_Dynamic->_base));
-        CHECK(123)
-        INIT_STRING_CONST(124, aux_String_2, "_Length)");
+        CHECK(128)
+        INIT_STRING_CONST(129, aux_String_2, "_Length)");
         LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-        CHECK(124)
+        CHECK(129)
     }
     else {
-            CHECK_REF(126, self, self_Refman)
-            INIT_STRING_CONST(126, aux_String_3, "_Length");
-            INIT_STRING_CONST(126, aux_String_4, "0");
+            CHECK_REF(131, self, self_Refman)
+            INIT_STRING_CONST(131, aux_String_3, "_Length");
+            INIT_STRING_CONST(131, aux_String_4, "0");
             LUMI_err = tl5_compiler_M_Expression_write_length(self->value, self->value_Refman, self->value_Dynamic, aux_String_3, aux_String_3_Refman, aux_String_4, aux_String_4_Refman, true);
-            CHECK(126)
+            CHECK(131)
         }
-    INIT_STRING_CONST(127, aux_String_5, ";\n");
+    INIT_STRING_CONST(132, aux_String_5, ";\n");
     LUMI_err = tl5_compiler_M_write(aux_String_5, aux_String_5_Refman);
-    CHECK(127)
-    CHECK_REF(128, self, self_Refman)
-    LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-    CHECK(128)
-    CHECK_REF(132, self, self_Refman)
-    CHECK_REF(132, self->target, self->target_Refman)
-    LUMI_err = tl5_compiler_M_TypeInstance_get_array_data_type_depth(self->target->result_type, self->target->result_type_Refman, &(data_type), &(data_type_Refman), &(depth));
     CHECK(132)
-    CHECK_REF(134, self, self_Refman)
-    CHECK_REF(134, self->value, self->value_Refman)
+    CHECK_REF(133, self, self_Refman)
+    LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
+    CHECK(133)
+    CHECK_REF(137, self, self_Refman)
+    CHECK_REF(137, self->target, self->target_Refman)
+    LUMI_err = tl5_compiler_M_TypeInstance_get_array_data_type_depth(self->target->result_type, self->target->result_type_Refman, &(data_type), &(data_type_Refman), &(depth));
+    CHECK(137)
+    CHECK_REF(139, self, self_Refman)
+    CHECK_REF(139, self->value, self->value_Refman)
     sequence_type = self->value->result_type;
     sequence_type_Refman = self->value->result_type_Refman;
     LUMI_inc_ref(sequence_type_Refman);
     for (n = 0; n < depth; ++n) {
-        CHECK_REF(136, self, self_Refman)
-        if (self->target_Dynamic == NULL) RAISE(136, empty_object)
+        CHECK_REF(141, self, self_Refman)
+        if (self->target_Dynamic == NULL) RAISE(141, empty_object)
         LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
-        CHECK(136)
+        CHECK(141)
         LUMI_err = tl5_compiler_M_write_array_value_length(n);
-        CHECK(137)
-        INIT_STRING_CONST(138, aux_String_6, " = ");
+        CHECK(142)
+        INIT_STRING_CONST(143, aux_String_6, " = ");
         LUMI_err = tl5_compiler_M_write(aux_String_6, aux_String_6_Refman);
-        CHECK(138)
+        CHECK(143)
         if (sequence_type != NULL && sequence_type_Refman->value != NULL) {
-            CHECK_REF(140, sequence_type, sequence_type_Refman)
+            CHECK_REF(145, sequence_type, sequence_type_Refman)
             if (sequence_type->parameters != NULL && sequence_type->parameters_Refman->value != NULL) {
-                CHECK_REF(141, sequence_type, sequence_type_Refman)
-                CHECK_REF(141, sequence_type->parameters, sequence_type->parameters_Refman)
-                CHECK_REF(141, sequence_type->parameters->first, sequence_type->parameters->first_Refman)
+                CHECK_REF(146, sequence_type, sequence_type_Refman)
+                CHECK_REF(146, sequence_type->parameters, sequence_type->parameters_Refman)
+                CHECK_REF(146, sequence_type->parameters->first, sequence_type->parameters->first_Refman)
                 aux_Ref_Manager = sequence_type_Refman;
                 sequence_type_Refman = sequence_type->parameters->first->item_Refman;
                 LUMI_inc_ref(sequence_type_Refman);
@@ -7417,65 +7434,65 @@ Returncode tl5_compiler_M_AssignExpression_write_array_preactions(tl5_compiler_M
                 }
         }
         if (sequence_type != NULL && sequence_type_Refman->value != NULL) {
-            CHECK_REF(147, sequence_type, sequence_type_Refman)
+            CHECK_REF(152, sequence_type, sequence_type_Refman)
             if (sequence_type->length != NULL && sequence_type->length_Refman->value != NULL) {
-                CHECK_REF(148, sequence_type, sequence_type_Refman)
-                if (sequence_type->length_Dynamic == NULL) RAISE(148, empty_object)
+                CHECK_REF(153, sequence_type, sequence_type_Refman)
+                if (sequence_type->length_Dynamic == NULL) RAISE(153, empty_object)
                 LUMI_err = sequence_type->length_Dynamic->get_constant_value(sequence_type->length, sequence_type->length_Refman, sequence_type->length_Dynamic, &(length_value), &(is_constant_length));
-                CHECK(148)
+                CHECK(153)
             }
         }
-        CHECK_REF(150, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(150, self, self_Refman)
-        CHECK_REF(150, self->value, self->value_Refman)
-        CHECK_REF(150, self->value->result_type, self->value->result_type_Refman)
+        CHECK_REF(155, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(155, self, self_Refman)
+        CHECK_REF(155, self->value, self->value_Refman)
+        CHECK_REF(155, self->value->result_type, self->value->result_type_Refman)
         if ((void*)self->value->result_type->type_data == tl5_compiler_M_glob->type_empty) {
-            INIT_STRING_CONST(151, aux_String_7, "0");
+            INIT_STRING_CONST(156, aux_String_7, "0");
             LUMI_err = tl5_compiler_M_write(aux_String_7, aux_String_7_Refman);
-            CHECK(151)
+            CHECK(156)
         }
         else {
                 if (is_constant_length) {
                     LUMI_err = tl5_compiler_M_write_int(length_value);
-                    CHECK(153)
+                    CHECK(158)
                 }
                 else {
-                    CHECK_REF(155, self, self_Refman)
-                    if (self->value_Dynamic == NULL) RAISE(155, empty_object)
+                    CHECK_REF(160, self, self_Refman)
+                    if (self->value_Dynamic == NULL) RAISE(160, empty_object)
                     LUMI_err = self->value_Dynamic->_base.write(&(self->value->_base), self->value_Refman, &(self->value_Dynamic->_base));
-                    CHECK(155)
+                    CHECK(160)
                     LUMI_err = tl5_compiler_M_write_array_value_length(n);
-                    CHECK(156)
+                    CHECK(161)
                 }
             }
-        INIT_STRING_CONST(157, aux_String_8, ";\n");
+        INIT_STRING_CONST(162, aux_String_8, ";\n");
         LUMI_err = tl5_compiler_M_write(aux_String_8, aux_String_8_Refman);
-        CHECK(157)
-        CHECK_REF(158, self, self_Refman)
-        LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-        CHECK(158)
-    }
-    CHECK_REF(160, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(160, data_type, data_type_Refman)
-    if ((void*)data_type->type_data == tl5_compiler_M_glob->type_string) {
-        CHECK_REF(161, self, self_Refman)
-        if (self->target_Dynamic == NULL) RAISE(161, empty_object)
-        LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
-        CHECK(161)
-        INIT_STRING_CONST(162, aux_String_9, "_String_length = ");
-        LUMI_err = tl5_compiler_M_write(aux_String_9, aux_String_9_Refman);
         CHECK(162)
         CHECK_REF(163, self, self_Refman)
-        INIT_STRING_CONST(164, aux_String_10, "_String_length");
-        INIT_STRING_CONST(164, aux_String_11, "NULL");
-        LUMI_err = tl5_compiler_M_Expression_write_length(self->value, self->value_Refman, self->value_Dynamic, aux_String_10, aux_String_10_Refman, aux_String_11, aux_String_11_Refman, false);
-        CHECK(163)
-        INIT_STRING_CONST(165, aux_String_12, ";\n");
-        LUMI_err = tl5_compiler_M_write(aux_String_12, aux_String_12_Refman);
-        CHECK(165)
-        CHECK_REF(166, self, self_Refman)
         LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
+        CHECK(163)
+    }
+    CHECK_REF(165, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(165, data_type, data_type_Refman)
+    if ((void*)data_type->type_data == tl5_compiler_M_glob->type_string) {
+        CHECK_REF(166, self, self_Refman)
+        if (self->target_Dynamic == NULL) RAISE(166, empty_object)
+        LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
         CHECK(166)
+        INIT_STRING_CONST(167, aux_String_9, "_String_length = ");
+        LUMI_err = tl5_compiler_M_write(aux_String_9, aux_String_9_Refman);
+        CHECK(167)
+        CHECK_REF(168, self, self_Refman)
+        INIT_STRING_CONST(169, aux_String_10, "_String_length");
+        INIT_STRING_CONST(169, aux_String_11, "NULL");
+        LUMI_err = tl5_compiler_M_Expression_write_length(self->value, self->value_Refman, self->value_Dynamic, aux_String_10, aux_String_10_Refman, aux_String_11, aux_String_11_Refman, false);
+        CHECK(168)
+        INIT_STRING_CONST(170, aux_String_12, ";\n");
+        LUMI_err = tl5_compiler_M_write(aux_String_12, aux_String_12_Refman);
+        CHECK(170)
+        CHECK_REF(171, self, self_Refman)
+        LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
+        CHECK(171)
     }
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_12_Refman);
@@ -7528,42 +7545,42 @@ Returncode tl5_compiler_M_AssignExpression_write_string_preactions(tl5_compiler_
     String* aux_String_7 = NULL;
     Ref_Manager* aux_String_7_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(169, self, self_Refman)
-    if (self->target_Dynamic == NULL) RAISE(169, empty_object)
+    CHECK_REF(174, self, self_Refman)
+    if (self->target_Dynamic == NULL) RAISE(174, empty_object)
     LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
-    CHECK(169)
-    INIT_STRING_CONST(170, aux_String_0, "_Max_length = ");
+    CHECK(174)
+    INIT_STRING_CONST(175, aux_String_0, "_Max_length = ");
     LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(170)
-    CHECK_REF(171, self, self_Refman)
-    INIT_STRING_CONST(171, aux_String_1, "_Max_length");
-    INIT_STRING_CONST(171, aux_String_2, "0");
-    LUMI_err = tl5_compiler_M_Expression_write_length(self->value, self->value_Refman, self->value_Dynamic, aux_String_1, aux_String_1_Refman, aux_String_2, aux_String_2_Refman, true);
-    CHECK(171)
-    INIT_STRING_CONST(172, aux_String_3, ";\n");
-    LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
-    CHECK(172)
-    CHECK_REF(173, self, self_Refman)
-    LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-    CHECK(173)
-    CHECK_REF(175, self, self_Refman)
-    if (self->target_Dynamic == NULL) RAISE(175, empty_object)
-    LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
     CHECK(175)
-    INIT_STRING_CONST(176, aux_String_4, "_Length = ");
-    LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
+    CHECK_REF(176, self, self_Refman)
+    INIT_STRING_CONST(176, aux_String_1, "_Max_length");
+    INIT_STRING_CONST(176, aux_String_2, "0");
+    LUMI_err = tl5_compiler_M_Expression_write_length(self->value, self->value_Refman, self->value_Dynamic, aux_String_1, aux_String_1_Refman, aux_String_2, aux_String_2_Refman, true);
     CHECK(176)
-    CHECK_REF(177, self, self_Refman)
-    INIT_STRING_CONST(178, aux_String_5, "_Length");
-    INIT_STRING_CONST(178, aux_String_6, "&Lumi_empty_int");
-    LUMI_err = tl5_compiler_M_Expression_write_length(self->value, self->value_Refman, self->value_Dynamic, aux_String_5, aux_String_5_Refman, aux_String_6, aux_String_6_Refman, false);
+    INIT_STRING_CONST(177, aux_String_3, ";\n");
+    LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
     CHECK(177)
-    INIT_STRING_CONST(179, aux_String_7, ";\n");
-    LUMI_err = tl5_compiler_M_write(aux_String_7, aux_String_7_Refman);
-    CHECK(179)
-    CHECK_REF(180, self, self_Refman)
+    CHECK_REF(178, self, self_Refman)
     LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
+    CHECK(178)
+    CHECK_REF(180, self, self_Refman)
+    if (self->target_Dynamic == NULL) RAISE(180, empty_object)
+    LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
     CHECK(180)
+    INIT_STRING_CONST(181, aux_String_4, "_Length = ");
+    LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
+    CHECK(181)
+    CHECK_REF(182, self, self_Refman)
+    INIT_STRING_CONST(183, aux_String_5, "_Length");
+    INIT_STRING_CONST(183, aux_String_6, "&Lumi_empty_int");
+    LUMI_err = tl5_compiler_M_Expression_write_length(self->value, self->value_Refman, self->value_Dynamic, aux_String_5, aux_String_5_Refman, aux_String_6, aux_String_6_Refman, false);
+    CHECK(182)
+    INIT_STRING_CONST(184, aux_String_7, ";\n");
+    LUMI_err = tl5_compiler_M_write(aux_String_7, aux_String_7_Refman);
+    CHECK(184)
+    CHECK_REF(185, self, self_Refman)
+    LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
+    CHECK(185)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_7_Refman);
     LUMI_var_dec_ref(aux_String_6_Refman);
@@ -7603,55 +7620,55 @@ Returncode tl5_compiler_M_AssignExpression_write_assign_refman(tl5_compiler_M_As
     String* aux_String_5 = NULL;
     Ref_Manager* aux_String_5_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(183, self, self_Refman)
-    CHECK_REF(183, self->target, self->target_Refman)
+    CHECK_REF(188, self, self_Refman)
+    CHECK_REF(188, self->target, self->target_Refman)
     LUMI_err = tl5_compiler_M_access_is_owner(self->target->access, &(aux_Bool_0));
-    CHECK(183)
+    CHECK(188)
     if (full_assign && (! aux_Bool_0)) {
-        INIT_STRING_CONST(184, aux_String_0, "LUMI_inc_ref(");
+        INIT_STRING_CONST(189, aux_String_0, "LUMI_inc_ref(");
         LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-        CHECK(184)
-        CHECK_REF(185, self, self_Refman)
-        if (self->value_Dynamic == NULL) RAISE(185, empty_object)
-        LUMI_err = self->value_Dynamic->write_refman(self->value, self->value_Refman, self->value_Dynamic);
-        CHECK(185)
-        INIT_STRING_CONST(186, aux_String_1, ");\n");
-        LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-        CHECK(186)
-        CHECK_REF(187, self, self_Refman)
-        LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-        CHECK(187)
-        INIT_STRING_CONST(189, aux_String_2, "LUMI_dec_ref(");
-        LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
         CHECK(189)
         CHECK_REF(190, self, self_Refman)
-        if (self->target_Dynamic == NULL) RAISE(190, empty_object)
-        LUMI_err = self->target_Dynamic->write_refman(self->target, self->target_Refman, self->target_Dynamic);
+        if (self->value_Dynamic == NULL) RAISE(190, empty_object)
+        LUMI_err = self->value_Dynamic->write_refman(self->value, self->value_Refman, self->value_Dynamic);
         CHECK(190)
-        INIT_STRING_CONST(191, aux_String_3, ");\n");
-        LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
+        INIT_STRING_CONST(191, aux_String_1, ");\n");
+        LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
         CHECK(191)
         CHECK_REF(192, self, self_Refman)
         LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
         CHECK(192)
+        INIT_STRING_CONST(194, aux_String_2, "LUMI_dec_ref(");
+        LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
+        CHECK(194)
+        CHECK_REF(195, self, self_Refman)
+        if (self->target_Dynamic == NULL) RAISE(195, empty_object)
+        LUMI_err = self->target_Dynamic->write_refman(self->target, self->target_Refman, self->target_Dynamic);
+        CHECK(195)
+        INIT_STRING_CONST(196, aux_String_3, ");\n");
+        LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
+        CHECK(196)
+        CHECK_REF(197, self, self_Refman)
+        LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
+        CHECK(197)
     }
-    CHECK_REF(194, self, self_Refman)
-    if (self->target_Dynamic == NULL) RAISE(194, empty_object)
+    CHECK_REF(199, self, self_Refman)
+    if (self->target_Dynamic == NULL) RAISE(199, empty_object)
     LUMI_err = self->target_Dynamic->write_refman(self->target, self->target_Refman, self->target_Dynamic);
-    CHECK(194)
-    INIT_STRING_CONST(195, aux_String_4, " = ");
+    CHECK(199)
+    INIT_STRING_CONST(200, aux_String_4, " = ");
     LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
-    CHECK(195)
-    CHECK_REF(196, self, self_Refman)
-    if (self->value_Dynamic == NULL) RAISE(196, empty_object)
+    CHECK(200)
+    CHECK_REF(201, self, self_Refman)
+    if (self->value_Dynamic == NULL) RAISE(201, empty_object)
     LUMI_err = self->value_Dynamic->write_refman(self->value, self->value_Refman, self->value_Dynamic);
-    CHECK(196)
-    INIT_STRING_CONST(197, aux_String_5, ";\n");
+    CHECK(201)
+    INIT_STRING_CONST(202, aux_String_5, ";\n");
     LUMI_err = tl5_compiler_M_write(aux_String_5, aux_String_5_Refman);
-    CHECK(197)
-    CHECK_REF(198, self, self_Refman)
+    CHECK(202)
+    CHECK_REF(203, self, self_Refman)
     LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-    CHECK(198)
+    CHECK(203)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_5_Refman);
     LUMI_var_dec_ref(aux_String_4_Refman);
@@ -7693,18 +7710,18 @@ Returncode tl5_compiler_M_AssignExpression_write_owner_assign_preactions(tl5_com
     Ref_Manager* aux_String_5_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(201, self, self_Refman)
+    CHECK_REF(206, self, self_Refman)
     if (! self->is_initialization) {
-        CHECK_REF(202, self, self_Refman)
+        CHECK_REF(207, self, self_Refman)
         if (self->aux_variable != NULL && self->aux_variable_Refman->value != NULL) {
-            CHECK_REF(204, self, self_Refman)
-            CHECK_REF(205, self, self_Refman)
-            CHECK_REF(206, self, self_Refman)
-            INIT_VAR(203, assign)
+            CHECK_REF(209, self, self_Refman)
+            CHECK_REF(210, self, self_Refman)
+            CHECK_REF(211, self, self_Refman)
+            INIT_VAR(208, assign)
             LUMI_err = tl5_compiler_M_AssignExpression_new(assign, assign_Refman, assign_Dynamic, self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic, &(self->aux_variable->_base), self->aux_variable_Refman, &(self->aux_variable_Dynamic->_base), self->original_value, self->original_value_Refman, self->original_value_Dynamic, false);
-            CHECK(203)
-            CHECK_REF(208, self, self_Refman)
-            CHECK_REF(208, assign, assign_Refman)
+            CHECK(208)
+            CHECK_REF(213, self, self_Refman)
+            CHECK_REF(213, assign, assign_Refman)
             aux_Ref_Manager = assign->value_Refman;
             assign->value_Refman = self->value_Refman;
             assign->value_Dynamic = self->value_Dynamic;
@@ -7713,16 +7730,16 @@ Returncode tl5_compiler_M_AssignExpression_write_owner_assign_preactions(tl5_com
             aux_Ref_Manager = NULL;
             assign->value = self->value;
             LUMI_err = tl5_compiler_M_AssignExpression_write_assign_preactions(assign, assign_Refman, assign_Dynamic, false);
-            CHECK(209)
+            CHECK(214)
             LUMI_err = tl5_compiler_M_AssignExpression_write_main_assign(assign, assign_Refman, assign_Dynamic);
-            CHECK(210)
+            CHECK(215)
             LUMI_err = tl5_compiler_M_AssignExpression_write_owner_null(assign, assign_Refman, assign_Dynamic);
-            CHECK(211)
-            CHECK_REF(212, self, self_Refman)
+            CHECK(216)
+            CHECK_REF(217, self, self_Refman)
             LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-            CHECK(212)
-            CHECK_REF(213, self, self_Refman)
-            CHECK_REF(213, self, self_Refman)
+            CHECK(217)
+            CHECK_REF(218, self, self_Refman)
+            CHECK_REF(218, self, self_Refman)
             aux_Ref_Manager = self->original_value_Refman;
             self->original_value_Refman = self->aux_variable_Refman;
             self->original_value_Dynamic = &(self->aux_variable_Dynamic->_base);
@@ -7730,8 +7747,8 @@ Returncode tl5_compiler_M_AssignExpression_write_owner_assign_preactions(tl5_com
             LUMI_dec_ref(aux_Ref_Manager);
             aux_Ref_Manager = NULL;
             self->original_value = &(self->aux_variable->_base);
-            CHECK_REF(214, self, self_Refman)
-            CHECK_REF(214, self, self_Refman)
+            CHECK_REF(219, self, self_Refman)
+            CHECK_REF(219, self, self_Refman)
             aux_Ref_Manager = self->value_Refman;
             self->value_Refman = self->aux_variable_Refman;
             self->value_Dynamic = &(self->aux_variable_Dynamic->_base);
@@ -7741,65 +7758,65 @@ Returncode tl5_compiler_M_AssignExpression_write_owner_assign_preactions(tl5_com
             self->value = &(self->aux_variable->_base);
         }
         LUMI_err = tl5_compiler_M_AssignExpression_write_left_delete(self, self_Refman, self_Dynamic);
-        CHECK(215)
-        CHECK_REF(216, self, self_Refman)
+        CHECK(220)
+        CHECK_REF(221, self, self_Refman)
         LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-        CHECK(216)
-        CHECK_REF(218, self, self_Refman)
-        CHECK_REF(218, self->target, self->target_Refman)
+        CHECK(221)
+        CHECK_REF(223, self, self_Refman)
+        CHECK_REF(223, self->target, self->target_Refman)
         if (self->target->access == tl5_compiler_M_Access_STRONG) {
-            INIT_STRING_CONST(219, aux_String_0, "LUMI_owner_dec_ref(");
+            INIT_STRING_CONST(224, aux_String_0, "LUMI_owner_dec_ref(");
             LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-            CHECK(219)
-            CHECK_REF(220, self, self_Refman)
-            if (self->target_Dynamic == NULL) RAISE(220, empty_object)
+            CHECK(224)
+            CHECK_REF(225, self, self_Refman)
+            if (self->target_Dynamic == NULL) RAISE(225, empty_object)
             LUMI_err = self->target_Dynamic->write_refman(self->target, self->target_Refman, self->target_Dynamic);
-            CHECK(220)
-            INIT_STRING_CONST(221, aux_String_1, ");\n");
+            CHECK(225)
+            INIT_STRING_CONST(226, aux_String_1, ");\n");
             LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-            CHECK(221)
-            CHECK_REF(222, self, self_Refman)
+            CHECK(226)
+            CHECK_REF(227, self, self_Refman)
             LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-            CHECK(222)
+            CHECK(227)
         }
         else {
-                INIT_STRING_CONST(224, aux_String_2, "free(");
+                INIT_STRING_CONST(229, aux_String_2, "free(");
                 LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-                CHECK(224)
-                CHECK_REF(225, self, self_Refman)
-                if (self->target_Dynamic == NULL) RAISE(225, empty_object)
+                CHECK(229)
+                CHECK_REF(230, self, self_Refman)
+                if (self->target_Dynamic == NULL) RAISE(230, empty_object)
                 LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
-                CHECK(225)
-                INIT_STRING_CONST(226, aux_String_3, ");\n");
+                CHECK(230)
+                INIT_STRING_CONST(231, aux_String_3, ");\n");
                 LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
-                CHECK(226)
-                CHECK_REF(227, self, self_Refman)
+                CHECK(231)
+                CHECK_REF(232, self, self_Refman)
                 LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-                CHECK(227)
+                CHECK(232)
             }
     }
-    CHECK_REF(231, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(231, self, self_Refman)
-    CHECK_REF(231, self->value, self->value_Refman)
-    CHECK_REF(231, self->value->result_type, self->value->result_type_Refman)
-    CHECK_REF(230, self, self_Refman)
-    CHECK_REF(230, self->target, self->target_Refman)
-    CHECK_REF(229, self, self_Refman)
-    CHECK_REF(229, self->value, self->value_Refman)
+    CHECK_REF(236, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(236, self, self_Refman)
+    CHECK_REF(236, self->value, self->value_Refman)
+    CHECK_REF(236, self->value->result_type, self->value->result_type_Refman)
+    CHECK_REF(235, self, self_Refman)
+    CHECK_REF(235, self->target, self->target_Refman)
+    CHECK_REF(234, self, self_Refman)
+    CHECK_REF(234, self->value, self->value_Refman)
     if (((self->value->access == tl5_compiler_M_Access_STRONG) && (self->target->access == tl5_compiler_M_Access_OWNER)) && ((void*)self->value->result_type->type_data != tl5_compiler_M_glob->type_empty)) {
-        INIT_STRING_CONST(232, aux_String_4, "LUMI_var_dec_ref(");
+        INIT_STRING_CONST(237, aux_String_4, "LUMI_var_dec_ref(");
         LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
-        CHECK(232)
-        CHECK_REF(233, self, self_Refman)
-        if (self->value_Dynamic == NULL) RAISE(233, empty_object)
+        CHECK(237)
+        CHECK_REF(238, self, self_Refman)
+        if (self->value_Dynamic == NULL) RAISE(238, empty_object)
         LUMI_err = self->value_Dynamic->write_refman(self->value, self->value_Refman, self->value_Dynamic);
-        CHECK(233)
-        INIT_STRING_CONST(234, aux_String_5, ");\n");
+        CHECK(238)
+        INIT_STRING_CONST(239, aux_String_5, ");\n");
         LUMI_err = tl5_compiler_M_write(aux_String_5, aux_String_5_Refman);
-        CHECK(234)
-        CHECK_REF(235, self, self_Refman)
+        CHECK(239)
+        CHECK_REF(240, self, self_Refman)
         LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-        CHECK(235)
+        CHECK(240)
     }
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_5_Refman);
@@ -7835,86 +7852,86 @@ Returncode tl5_compiler_M_AssignExpression_write_assign_dynamic(tl5_compiler_M_A
     String* aux_String_4 = NULL;
     Ref_Manager* aux_String_4_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(238, self, self_Refman)
-    if (self->target_Dynamic == NULL) RAISE(238, empty_object)
+    CHECK_REF(243, self, self_Refman)
+    if (self->target_Dynamic == NULL) RAISE(243, empty_object)
     LUMI_err = self->target_Dynamic->write_dynamic(self->target, self->target_Refman, self->target_Dynamic);
-    CHECK(238)
-    INIT_STRING_CONST(239, aux_String_0, " = ");
+    CHECK(243)
+    INIT_STRING_CONST(244, aux_String_0, " = ");
     LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(239)
-    CHECK_REF(242, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(242, self, self_Refman)
-    CHECK_REF(242, self->value, self->value_Refman)
-    CHECK_REF(242, self->value->result_type, self->value->result_type_Refman)
-    CHECK_REF(241, self, self_Refman)
-    CHECK_REF(241, self->value, self->value_Refman)
-    CHECK_REF(240, self, self_Refman)
-    CHECK_REF(240, self->value, self->value_Refman)
-    CHECK_REF(240, self->value->result_type, self->value->result_type_Refman)
-    CHECK_REF(240, self->value->result_type->type_data, self->value->result_type->type_data_Refman)
+    CHECK(244)
+    CHECK_REF(247, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(247, self, self_Refman)
+    CHECK_REF(247, self->value, self->value_Refman)
+    CHECK_REF(247, self->value->result_type, self->value->result_type_Refman)
+    CHECK_REF(246, self, self_Refman)
+    CHECK_REF(246, self->value, self->value_Refman)
+    CHECK_REF(245, self, self_Refman)
+    CHECK_REF(245, self->value, self->value_Refman)
+    CHECK_REF(245, self->value->result_type, self->value->result_type_Refman)
+    CHECK_REF(245, self->value->result_type->type_data, self->value->result_type->type_data_Refman)
     if (((! self->value->result_type->type_data->is_dynamic) && (! self->value->is_generic_cast)) && ((void*)self->value->result_type->type_data != tl5_compiler_M_glob->type_empty)) {
-        INIT_STRING_CONST(243, aux_String_1, "&");
+        INIT_STRING_CONST(248, aux_String_1, "&");
         LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-        CHECK(243)
-        CHECK_REF(244, self, self_Refman)
-        CHECK_REF(244, self->value, self->value_Refman)
+        CHECK(248)
+        CHECK_REF(249, self, self_Refman)
+        CHECK_REF(249, self->value, self->value_Refman)
         LUMI_err = tl5_compiler_M_TypeInstance_write_cname(self->value->result_type, self->value->result_type_Refman);
-        CHECK(244)
-        INIT_STRING_CONST(245, aux_String_2, "_dynamic");
+        CHECK(249)
+        INIT_STRING_CONST(250, aux_String_2, "_dynamic");
         LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-        CHECK(245)
+        CHECK(250)
     }
     else {
-            CHECK_REF(249, self, self_Refman)
-            CHECK_REF(249, self->value, self->value_Refman)
-            CHECK_REF(248, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-            CHECK_REF(248, self, self_Refman)
-            CHECK_REF(248, self->value, self->value_Refman)
-            CHECK_REF(248, self->value->result_type, self->value->result_type_Refman)
-            CHECK_REF(247, self, self_Refman)
-            CHECK_REF(247, self->target, self->target_Refman)
-            CHECK_REF(246, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-            CHECK_REF(246, self, self_Refman)
-            CHECK_REF(246, self->target, self->target_Refman)
-            CHECK_REF(246, self->target->result_type, self->target->result_type_Refman)
+            CHECK_REF(254, self, self_Refman)
+            CHECK_REF(254, self->value, self->value_Refman)
+            CHECK_REF(253, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+            CHECK_REF(253, self, self_Refman)
+            CHECK_REF(253, self->value, self->value_Refman)
+            CHECK_REF(253, self->value->result_type, self->value->result_type_Refman)
+            CHECK_REF(252, self, self_Refman)
+            CHECK_REF(252, self->target, self->target_Refman)
+            CHECK_REF(251, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+            CHECK_REF(251, self, self_Refman)
+            CHECK_REF(251, self->target, self->target_Refman)
+            CHECK_REF(251, self->target->result_type, self->target->result_type_Refman)
             if (((((void*)self->target->result_type->type_data == tl5_compiler_M_glob->type_generic) || self->target->is_generic_cast) && ((void*)self->value->result_type->type_data != tl5_compiler_M_glob->type_generic)) && (! self->value->is_generic_cast)) {
-                INIT_STRING_CONST(250, aux_String_3, "(Generic_Type_Dynamic*)");
+                INIT_STRING_CONST(255, aux_String_3, "(Generic_Type_Dynamic*)");
                 LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
-                CHECK(250)
-                CHECK_REF(251, self, self_Refman)
-                if (self->value_Dynamic == NULL) RAISE(251, empty_object)
+                CHECK(255)
+                CHECK_REF(256, self, self_Refman)
+                if (self->value_Dynamic == NULL) RAISE(256, empty_object)
                 LUMI_err = self->value_Dynamic->write_dynamic_safe(self->value, self->value_Refman, self->value_Dynamic);
-                CHECK(251)
+                CHECK(256)
             }
             else {
-                CHECK_REF(254, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-                CHECK_REF(254, self, self_Refman)
-                CHECK_REF(254, self->target, self->target_Refman)
-                CHECK_REF(254, self->target->result_type, self->target->result_type_Refman)
-                CHECK_REF(253, self, self_Refman)
-                CHECK_REF(253, self->target, self->target_Refman)
-                CHECK_REF(252, self, self_Refman)
-                CHECK_REF(252, self->value, self->value_Refman)
+                CHECK_REF(259, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+                CHECK_REF(259, self, self_Refman)
+                CHECK_REF(259, self->target, self->target_Refman)
+                CHECK_REF(259, self->target->result_type, self->target->result_type_Refman)
+                CHECK_REF(258, self, self_Refman)
+                CHECK_REF(258, self->target, self->target_Refman)
+                CHECK_REF(257, self, self_Refman)
+                CHECK_REF(257, self->value, self->value_Refman)
                 if ((self->value->is_generic_cast && (! self->target->is_generic_cast)) && (! ((void*)self->target->result_type->type_data == tl5_compiler_M_glob->type_generic))) {
-                    CHECK_REF(255, self, self_Refman)
-                    if (self->value_Dynamic == NULL) RAISE(255, empty_object)
+                    CHECK_REF(260, self, self_Refman)
+                    if (self->value_Dynamic == NULL) RAISE(260, empty_object)
                     LUMI_err = self->value_Dynamic->write_dynamic_safe(self->value, self->value_Refman, self->value_Dynamic);
-                    CHECK(255)
+                    CHECK(260)
                 }
                 else {
-                    CHECK_REF(257, self, self_Refman)
-                    if (self->value_Dynamic == NULL) RAISE(257, empty_object)
+                    CHECK_REF(262, self, self_Refman)
+                    if (self->value_Dynamic == NULL) RAISE(262, empty_object)
                     LUMI_err = self->value_Dynamic->write_dynamic(self->value, self->value_Refman, self->value_Dynamic);
-                    CHECK(257)
+                    CHECK(262)
                 }
             }
         }
-    INIT_STRING_CONST(258, aux_String_4, ";\n");
+    INIT_STRING_CONST(263, aux_String_4, ";\n");
     LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
-    CHECK(258)
-    CHECK_REF(259, self, self_Refman)
+    CHECK(263)
+    CHECK_REF(264, self, self_Refman)
     LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-    CHECK(259)
+    CHECK(264)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_4_Refman);
     LUMI_var_dec_ref(aux_String_3_Refman);
@@ -7984,37 +8001,37 @@ Returncode tl5_compiler_M_AssignExpression_write_left_delete(tl5_compiler_M_Assi
     Ref_Manager* aux_String_14_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(262, self, self_Refman)
-    CHECK_REF(262, self->target, self->target_Refman)
-    CHECK_REF(262, self->target->result_type, self->target->result_type_Refman)
+    CHECK_REF(267, self, self_Refman)
+    CHECK_REF(267, self->target, self->target_Refman)
+    CHECK_REF(267, self->target->result_type, self->target->result_type_Refman)
     type_data = self->target->result_type->type_data;
     type_data_Refman = self->target->result_type->type_data_Refman;
     LUMI_inc_ref(type_data_Refman);
     type_data_Dynamic = self->target->result_type->type_data_Dynamic;
-    CHECK_REF(263, type_data, type_data_Refman)
+    CHECK_REF(268, type_data, type_data_Refman)
     if (type_data->is_dynamic) {
-        INIT_STRING_CONST(264, aux_String_0, "if (");
+        INIT_STRING_CONST(269, aux_String_0, "if (");
         LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-        CHECK(264)
-        CHECK_REF(265, self, self_Refman)
-        if (self->target_Dynamic == NULL) RAISE(265, empty_object)
+        CHECK(269)
+        CHECK_REF(270, self, self_Refman)
+        if (self->target_Dynamic == NULL) RAISE(270, empty_object)
         LUMI_err = self->target_Dynamic->write_dynamic(self->target, self->target_Refman, self->target_Dynamic);
-        CHECK(265)
-        INIT_STRING_CONST(266, aux_String_1, " != NULL) ");
+        CHECK(270)
+        INIT_STRING_CONST(271, aux_String_1, " != NULL) ");
         LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-        CHECK(266)
-        CHECK_REF(267, self, self_Refman)
-        if (self->target_Dynamic == NULL) RAISE(267, empty_object)
+        CHECK(271)
+        CHECK_REF(272, self, self_Refman)
+        if (self->target_Dynamic == NULL) RAISE(272, empty_object)
         LUMI_err = self->target_Dynamic->write_dynamic_safe(self->target, self->target_Refman, self->target_Dynamic);
-        CHECK(267)
-        INIT_STRING_CONST(268, aux_String_2, "->");
+        CHECK(272)
+        INIT_STRING_CONST(273, aux_String_2, "->");
         LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-        CHECK(268)
+        CHECK(273)
         while (true) {
-            CHECK_REF(270, type_data, type_data_Refman)
+            CHECK_REF(275, type_data, type_data_Refman)
             if (!(type_data->base_type != NULL && type_data->base_type_Refman->value != NULL)) break;
-            CHECK_REF(271, type_data, type_data_Refman)
-            CHECK_REF(271, type_data->base_type, type_data->base_type_Refman)
+            CHECK_REF(276, type_data, type_data_Refman)
+            CHECK_REF(276, type_data->base_type, type_data->base_type_Refman)
             aux_Ref_Manager = type_data_Refman;
             type_data_Refman = type_data->base_type->type_data_Refman;
             type_data_Dynamic = type_data->base_type->type_data_Dynamic;
@@ -8022,84 +8039,84 @@ Returncode tl5_compiler_M_AssignExpression_write_left_delete(tl5_compiler_M_Assi
             LUMI_dec_ref(aux_Ref_Manager);
             aux_Ref_Manager = NULL;
             type_data = type_data->base_type->type_data;
-            CHECK_REF(272, type_data, type_data_Refman)
+            CHECK_REF(277, type_data, type_data_Refman)
             if (!(type_data->is_dynamic)) break;
-            INIT_STRING_CONST(273, aux_String_3, "_base.");
+            INIT_STRING_CONST(278, aux_String_3, "_base.");
             LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
-            CHECK(273)
+            CHECK(278)
         }
-        INIT_STRING_CONST(274, aux_String_4, "_del(");
+        INIT_STRING_CONST(279, aux_String_4, "_del(");
         LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
-        CHECK(274)
+        CHECK(279)
     }
     else {
-            CHECK_REF(275, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+            CHECK_REF(280, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
             if ((void*)type_data != tl5_compiler_M_glob->type_array) {
-                if (type_data_Dynamic == NULL) RAISE(276, empty_object)
+                if (type_data_Dynamic == NULL) RAISE(281, empty_object)
                 LUMI_err = type_data_Dynamic->write_cname(type_data, type_data_Refman, type_data_Dynamic);
-                CHECK(276)
-                INIT_STRING_CONST(277, aux_String_5, "_Del(");
+                CHECK(281)
+                INIT_STRING_CONST(282, aux_String_5, "_Del(");
                 LUMI_err = tl5_compiler_M_write(aux_String_5, aux_String_5_Refman);
-                CHECK(277)
+                CHECK(282)
             }
             else {
-                CHECK_REF(280, self, self_Refman)
-                CHECK_REF(280, self->target, self->target_Refman)
+                CHECK_REF(285, self, self_Refman)
+                CHECK_REF(285, self->target, self->target_Refman)
                 LUMI_err = tl5_compiler_M_TypeInstance_get_array_data_type_depth(self->target->result_type, self->target->result_type_Refman, &(data_type), &(data_type_Refman), &(aux_Int_0));
-                CHECK(280)
-                CHECK_REF(282, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-                CHECK_REF(282, data_type, data_type_Refman)
+                CHECK(285)
+                CHECK_REF(287, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+                CHECK_REF(287, data_type, data_type_Refman)
                 if ((void*)data_type->type_data == tl5_compiler_M_glob->type_string) {
-            INIT_STRING_CONST(283, aux_String_6, "free(");
+            INIT_STRING_CONST(288, aux_String_6, "free(");
             LUMI_err = tl5_compiler_M_write(aux_String_6, aux_String_6_Refman);
-            CHECK(283)
-            CHECK_REF(284, self, self_Refman)
-            if (self->target_Dynamic == NULL) RAISE(284, empty_object)
+            CHECK(288)
+            CHECK_REF(289, self, self_Refman)
+            if (self->target_Dynamic == NULL) RAISE(289, empty_object)
             LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
-            CHECK(284)
-            INIT_STRING_CONST(285, aux_String_7, "_String_length);\n");
+            CHECK(289)
+            INIT_STRING_CONST(290, aux_String_7, "_String_length);\n");
             LUMI_err = tl5_compiler_M_write(aux_String_7, aux_String_7_Refman);
-            CHECK(285)
+            CHECK(290)
         }
                 else {
-                CHECK_REF(286, data_type, data_type_Refman)
-                CHECK_REF(286, data_type->type_data, data_type->type_data_Refman)
+                CHECK_REF(291, data_type, data_type_Refman)
+                CHECK_REF(291, data_type->type_data, data_type->type_data_Refman)
                 if (! data_type->type_data->is_primitive) {
-                    INIT_STRING_CONST(287, aux_String_8, "ARRAY_DEL(");
+                    INIT_STRING_CONST(292, aux_String_8, "ARRAY_DEL(");
                     LUMI_err = tl5_compiler_M_write(aux_String_8, aux_String_8_Refman);
-                    CHECK(287)
-                    LUMI_err = tl5_compiler_M_TypeInstance_write_cname(data_type, data_type_Refman);
-                    CHECK(288)
-                    INIT_STRING_CONST(289, aux_String_9, ", ");
-                    LUMI_err = tl5_compiler_M_write(aux_String_9, aux_String_9_Refman);
-                    CHECK(289)
-                    CHECK_REF(290, self, self_Refman)
-                    if (self->target_Dynamic == NULL) RAISE(290, empty_object)
-                    LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
-                    CHECK(290)
-                    INIT_STRING_CONST(291, aux_String_10, ", ");
-                    LUMI_err = tl5_compiler_M_write(aux_String_10, aux_String_10_Refman);
-                    CHECK(291)
-                    CHECK_REF(292, self, self_Refman)
-                    INIT_STRING_CONST(292, aux_String_11, "_Length");
-                    INIT_STRING_CONST(292, aux_String_12, "0");
-                    LUMI_err = tl5_compiler_M_Expression_write_length(self->target, self->target_Refman, self->target_Dynamic, aux_String_11, aux_String_11_Refman, aux_String_12, aux_String_12_Refman, true);
                     CHECK(292)
-                    INIT_STRING_CONST(293, aux_String_13, ")\n");
-                    LUMI_err = tl5_compiler_M_write(aux_String_13, aux_String_13_Refman);
+                    LUMI_err = tl5_compiler_M_TypeInstance_write_cname(data_type, data_type_Refman);
                     CHECK(293)
+                    INIT_STRING_CONST(294, aux_String_9, ", ");
+                    LUMI_err = tl5_compiler_M_write(aux_String_9, aux_String_9_Refman);
+                    CHECK(294)
+                    CHECK_REF(295, self, self_Refman)
+                    if (self->target_Dynamic == NULL) RAISE(295, empty_object)
+                    LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
+                    CHECK(295)
+                    INIT_STRING_CONST(296, aux_String_10, ", ");
+                    LUMI_err = tl5_compiler_M_write(aux_String_10, aux_String_10_Refman);
+                    CHECK(296)
+                    CHECK_REF(297, self, self_Refman)
+                    INIT_STRING_CONST(297, aux_String_11, "_Length");
+                    INIT_STRING_CONST(297, aux_String_12, "0");
+                    LUMI_err = tl5_compiler_M_Expression_write_length(self->target, self->target_Refman, self->target_Dynamic, aux_String_11, aux_String_11_Refman, aux_String_12, aux_String_12_Refman, true);
+                    CHECK(297)
+                    INIT_STRING_CONST(298, aux_String_13, ")\n");
+                    LUMI_err = tl5_compiler_M_write(aux_String_13, aux_String_13_Refman);
+                    CHECK(298)
                 }
             }
                 goto LUMI_cleanup;
             }
         }
-    CHECK_REF(295, self, self_Refman)
-    if (self->target_Dynamic == NULL) RAISE(295, empty_object)
+    CHECK_REF(300, self, self_Refman)
+    if (self->target_Dynamic == NULL) RAISE(300, empty_object)
     LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
-    CHECK(295)
-    INIT_STRING_CONST(296, aux_String_14, ");\n");
+    CHECK(300)
+    INIT_STRING_CONST(301, aux_String_14, ");\n");
     LUMI_err = tl5_compiler_M_write(aux_String_14, aux_String_14_Refman);
-    CHECK(296)
+    CHECK(301)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_14_Refman);
     LUMI_var_dec_ref(aux_String_13_Refman);
@@ -8131,14 +8148,14 @@ Returncode tl5_compiler_M_AssignExpression_write(tl5_compiler_M_AssignExpression
     Bool aux_Bool_0 = 0;
     LUMI_inc_ref(self_Refman);
     LUMI_err = tl5_compiler_M_AssignExpression_write_main_assign(self, self_Refman, self_Dynamic);
-    CHECK(300)
-    CHECK_REF(301, self, self_Refman)
-    CHECK_REF(301, self->target, self->target_Refman)
+    CHECK(305)
+    CHECK_REF(306, self, self_Refman)
+    CHECK_REF(306, self->target, self->target_Refman)
     LUMI_err = tl5_compiler_M_access_is_owner(self->target->access, &(aux_Bool_0));
-    CHECK(301)
+    CHECK(306)
     if (aux_Bool_0) {
         LUMI_err = tl5_compiler_M_AssignExpression_write_owner_null(self, self_Refman, self_Dynamic);
-        CHECK(302)
+        CHECK(307)
     }
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
@@ -8158,20 +8175,20 @@ Returncode tl5_compiler_M_AssignExpression_write_main_assign(tl5_compiler_M_Assi
     String* aux_String_1 = NULL;
     Ref_Manager* aux_String_1_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(305, self, self_Refman)
-    if (self->target_Dynamic == NULL) RAISE(305, empty_object)
+    CHECK_REF(310, self, self_Refman)
+    if (self->target_Dynamic == NULL) RAISE(310, empty_object)
     LUMI_err = self->target_Dynamic->_base.write(&(self->target->_base), self->target_Refman, &(self->target_Dynamic->_base));
-    CHECK(305)
-    INIT_STRING_CONST(306, aux_String_0, " = ");
+    CHECK(310)
+    INIT_STRING_CONST(311, aux_String_0, " = ");
     LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(306)
-    CHECK_REF(307, self, self_Refman)
-    if (self->value_Dynamic == NULL) RAISE(307, empty_object)
+    CHECK(311)
+    CHECK_REF(312, self, self_Refman)
+    if (self->value_Dynamic == NULL) RAISE(312, empty_object)
     LUMI_err = self->value_Dynamic->write_cast(self->value, self->value_Refman, self->value_Dynamic);
-    CHECK(307)
-    INIT_STRING_CONST(308, aux_String_1, ";\n");
+    CHECK(312)
+    INIT_STRING_CONST(313, aux_String_1, ";\n");
     LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-    CHECK(308)
+    CHECK(313)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_1_Refman);
     LUMI_var_dec_ref(aux_String_0_Refman);
@@ -8187,9 +8204,9 @@ Returncode tl5_compiler_M_AssignExpression_write_assign(tl5_compiler_M_AssignExp
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
     LUMI_err = tl5_compiler_M_AssignExpression_write_assign_preactions(self, self_Refman, self_Dynamic, false);
-    CHECK(311)
+    CHECK(316)
     LUMI_err = tl5_compiler_M_AssignExpression_write_main_assign(self, self_Refman, self_Dynamic);
-    CHECK(312)
+    CHECK(317)
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
     return LUMI_err;
@@ -8208,34 +8225,34 @@ Returncode tl5_compiler_M_AssignExpression_write_owner_null(tl5_compiler_M_Assig
     String* aux_String_1 = NULL;
     Ref_Manager* aux_String_1_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(316, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(316, self, self_Refman)
-    CHECK_REF(316, self->value, self->value_Refman)
-    CHECK_REF(316, self->value->result_type, self->value->result_type_Refman)
+    CHECK_REF(321, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(321, self, self_Refman)
+    CHECK_REF(321, self->value, self->value_Refman)
+    CHECK_REF(321, self->value->result_type, self->value->result_type_Refman)
     if ((void*)self->value->result_type->type_data == tl5_compiler_M_glob->type_empty) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(318, self, self_Refman)
+    CHECK_REF(323, self, self_Refman)
     LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-    CHECK(318)
-    CHECK_REF(319, self, self_Refman)
+    CHECK(323)
+    CHECK_REF(324, self, self_Refman)
     LUMI_err = tl5_compiler_M_Expression_write_assign_null(self->original_value, self->original_value_Refman, self->original_value_Dynamic);
-    CHECK(319)
-    CHECK_REF(321, self, self_Refman)
-    CHECK_REF(321, self->target, self->target_Refman)
-    CHECK_REF(320, self, self_Refman)
-    CHECK_REF(320, self->value, self->value_Refman)
+    CHECK(324)
+    CHECK_REF(326, self, self_Refman)
+    CHECK_REF(326, self->target, self->target_Refman)
+    CHECK_REF(325, self, self_Refman)
+    CHECK_REF(325, self->value, self->value_Refman)
     if ((self->value->access == tl5_compiler_M_Access_OWNER) && (self->target->access == tl5_compiler_M_Access_STRONG)) {
-        CHECK_REF(322, self, self_Refman)
+        CHECK_REF(327, self, self_Refman)
         LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(self->_base.code_node, self->_base.code_node_Refman, self->_base.code_node_Dynamic);
-        CHECK(322)
-        INIT_STRING_CONST(323, aux_String_0, "INIT_NEW_REFMAN");
-        CHECK_REF(323, self, self_Refman)
+        CHECK(327)
+        INIT_STRING_CONST(328, aux_String_0, "INIT_NEW_REFMAN");
+        CHECK_REF(328, self, self_Refman)
         LUMI_err = tl5_compiler_M_Expression_write_macro_init(&(self->_base), self_Refman, &(self_Dynamic->_base), aux_String_0, aux_String_0_Refman, self->target, self->target_Refman, self->target_Dynamic);
-        CHECK(323)
-        INIT_STRING_CONST(324, aux_String_1, ")\n");
+        CHECK(328)
+        INIT_STRING_CONST(329, aux_String_1, ")\n");
         LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-        CHECK(324)
+        CHECK(329)
     }
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_1_Refman);
@@ -34970,36 +34987,39 @@ Returncode tl5_compiler_M_TypeInstance_check_assign_to(tl5_compiler_M_TypeInstan
     String aux_String_5_Var = {0};
     String* aux_String_5 = NULL;
     Ref_Manager* aux_String_5_Refman = NULL;
-    Bool aux_Bool_3 = 0;
-    Bool aux_Bool_4 = 0;
     String aux_String_6_Var = {0};
     String* aux_String_6 = NULL;
     Ref_Manager* aux_String_6_Refman = NULL;
+    Bool aux_Bool_3 = 0;
+    Bool aux_Bool_4 = 0;
     String aux_String_7_Var = {0};
     String* aux_String_7 = NULL;
     Ref_Manager* aux_String_7_Refman = NULL;
-    Bool aux_Bool_5 = 0;
     String aux_String_8_Var = {0};
     String* aux_String_8 = NULL;
     Ref_Manager* aux_String_8_Refman = NULL;
-    Bool aux_Bool_6 = 0;
+    Bool aux_Bool_5 = 0;
     String aux_String_9_Var = {0};
     String* aux_String_9 = NULL;
     Ref_Manager* aux_String_9_Refman = NULL;
+    Bool aux_Bool_6 = 0;
     String aux_String_10_Var = {0};
     String* aux_String_10 = NULL;
     Ref_Manager* aux_String_10_Refman = NULL;
-    Bool aux_Bool_7 = 0;
-    Bool aux_Bool_8 = 0;
     String aux_String_11_Var = {0};
     String* aux_String_11 = NULL;
     Ref_Manager* aux_String_11_Refman = NULL;
+    Bool aux_Bool_7 = 0;
+    Bool aux_Bool_8 = 0;
     String aux_String_12_Var = {0};
     String* aux_String_12 = NULL;
     Ref_Manager* aux_String_12_Refman = NULL;
     String aux_String_13_Var = {0};
     String* aux_String_13 = NULL;
     Ref_Manager* aux_String_13_Refman = NULL;
+    String aux_String_14_Var = {0};
+    String* aux_String_14 = NULL;
+    Ref_Manager* aux_String_14_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(target_Refman);
@@ -35071,87 +35091,99 @@ Returncode tl5_compiler_M_TypeInstance_check_assign_to(tl5_compiler_M_TypeInstan
         }
         CHECK_REF(272, self, self_Refman)
         if (self->reference_path != NULL && self->reference_path_Refman->value != NULL) {
-            CHECK_REF(274, self, self_Refman)
+            CHECK_REF(273, self, self_Refman)
             LUMI_err = tl5_compiler_M_ReferencePath_is_conditional(self->reference_path, self->reference_path_Refman, &(aux_Bool_2));
             CHECK(273)
-            CHECK_REF(273, self, self_Refman)
-            CHECK_REF(273, self->reference_path, self->reference_path_Refman)
-            if ((self->reference_path->field != NULL && self->reference_path->field_Refman->value != NULL) && (! aux_Bool_2)) {
-                TEST_ASSERT(275, node != NULL && node_Refman->value != NULL)
-                INIT_STRING_CONST(277, aux_String_5, "cannot move non-conditional owner field");
-                CHECK_REF(278, self, self_Refman)
-                LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error_ref(node, node_Refman, node_Dynamic, aux_String_5, aux_String_5_Refman, self->reference_path, self->reference_path_Refman);
-                CHECK(276)
+            if (! aux_Bool_2) {
+                CHECK_REF(274, self, self_Refman)
+                CHECK_REF(274, self->reference_path, self->reference_path_Refman)
+                if (self->reference_path->field != NULL && self->reference_path->field_Refman->value != NULL) {
+                    TEST_ASSERT(275, node != NULL && node_Refman->value != NULL)
+                    INIT_STRING_CONST(277, aux_String_5, "cannot move non-conditional owner field");
+                    CHECK_REF(278, self, self_Refman)
+                    LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error_ref(node, node_Refman, node_Dynamic, aux_String_5, aux_String_5_Refman, self->reference_path, self->reference_path_Refman);
+                    CHECK(276)
+                }
+                CHECK_REF(279, self, self_Refman)
+                CHECK_REF(279, self->reference_path, self->reference_path_Refman)
+                CHECK_REF(279, self->reference_path->variable, self->reference_path->variable_Refman)
+                if (! (self->reference_path->variable->_base.parent != NULL && self->reference_path->variable->_base.parent_Refman->value != NULL)) {
+                    TEST_ASSERT(280, node != NULL && node_Refman->value != NULL)
+                    INIT_STRING_CONST(282, aux_String_6, "cannot move non-conditional global owner");
+                    CHECK_REF(283, self, self_Refman)
+                    LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error_ref(node, node_Refman, node_Dynamic, aux_String_6, aux_String_6_Refman, self->reference_path, self->reference_path_Refman);
+                    CHECK(281)
+                }
             }
         }
     }
     LUMI_err = tl5_compiler_M_access_is_user(self_access, &(aux_Bool_3));
-    CHECK(279)
+    CHECK(284)
     LUMI_err = tl5_compiler_M_access_is_user(target_access, &(aux_Bool_4));
-    CHECK(279)
+    CHECK(284)
     if (((! aux_Bool_4) && aux_Bool_3) || ((target_access == tl5_compiler_M_Access_S_VAR) && (self_access == tl5_compiler_M_Access_VAR))) {
-        TEST_ASSERT(282, node != NULL && node_Refman->value != NULL)
-        INIT_STRING_CONST(284, aux_String_6, "cannot assign value with access");
-        CHECK_REF(285, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(285, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
-        if ((self_access) < 0 || (self_access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(285, slice_index)
-        INIT_STRING_CONST(286, aux_String_7, "into value with access");
-        CHECK_REF(287, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(287, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
-        if ((target_access) < 0 || (target_access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(287, slice_index)
-        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error2(node, node_Refman, node_Dynamic, aux_String_6, aux_String_6_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + self_access, tl5_compiler_M_glob->access_names_Refman, aux_String_7, aux_String_7_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + target_access, tl5_compiler_M_glob->access_names_Refman);
-        CHECK(283)
+        TEST_ASSERT(287, node != NULL && node_Refman->value != NULL)
+        INIT_STRING_CONST(289, aux_String_7, "cannot assign value with access");
+        CHECK_REF(290, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(290, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
+        if ((self_access) < 0 || (self_access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(290, slice_index)
+        INIT_STRING_CONST(291, aux_String_8, "into value with access");
+        CHECK_REF(292, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(292, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
+        if ((target_access) < 0 || (target_access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(292, slice_index)
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error2(node, node_Refman, node_Dynamic, aux_String_7, aux_String_7_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + self_access, tl5_compiler_M_glob->access_names_Refman, aux_String_8, aux_String_8_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + target_access, tl5_compiler_M_glob->access_names_Refman);
+        CHECK(288)
     }
     LUMI_err = tl5_compiler_M_access_has_refman(self_access, &(aux_Bool_5));
-    CHECK(288)
+    CHECK(293)
     if ((target_access == tl5_compiler_M_Access_WEAK) && (! aux_Bool_5)) {
-        TEST_ASSERT(290, node != NULL && node_Refman->value != NULL)
-        INIT_STRING_CONST(292, aux_String_8, "assigning into a weak reference an illegal access");
-        CHECK_REF(293, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(293, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
-        if ((self_access) < 0 || (self_access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(293, slice_index)
-        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(node, node_Refman, node_Dynamic, aux_String_8, aux_String_8_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + self_access, tl5_compiler_M_glob->access_names_Refman);
-        CHECK(291)
+        TEST_ASSERT(295, node != NULL && node_Refman->value != NULL)
+        INIT_STRING_CONST(297, aux_String_9, "assigning into a weak reference an illegal access");
+        CHECK_REF(298, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(298, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
+        if ((self_access) < 0 || (self_access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(298, slice_index)
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(node, node_Refman, node_Dynamic, aux_String_9, aux_String_9_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + self_access, tl5_compiler_M_glob->access_names_Refman);
+        CHECK(296)
     }
-    CHECK_REF(295, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(295, target, target_Refman)
-    CHECK_REF(294, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(294, self, self_Refman)
+    CHECK_REF(300, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(300, target, target_Refman)
+    CHECK_REF(299, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(299, self, self_Refman)
     if (((void*)self->type_data == tl5_compiler_M_glob->type_pointer) && ((void*)target->type_data == tl5_compiler_M_glob->type_pointer)) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(298, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(298, target, target_Refman)
-    CHECK_REF(297, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(297, self, self_Refman)
+    CHECK_REF(303, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(303, target, target_Refman)
+    CHECK_REF(302, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(302, self, self_Refman)
     if (((void*)self->type_data == tl5_compiler_M_glob->type_generic) && ((void*)target->type_data == tl5_compiler_M_glob->type_generic)) {
-        CHECK_REF(299, self, self_Refman)
-        CHECK_REF(299, target, target_Refman)
+        CHECK_REF(304, self, self_Refman)
+        CHECK_REF(304, target, target_Refman)
         LUMI_err = String_equal(self->name, self->name_Refman, target->name, target->name_Refman, &(aux_Bool_6));
-        CHECK(299)
+        CHECK(304)
         if (! aux_Bool_6) {
-            TEST_ASSERT(300, node != NULL && node_Refman->value != NULL)
-            INIT_STRING_CONST(302, aux_String_9, "cannot assign generic subtype");
-            CHECK_REF(303, self, self_Refman)
-            INIT_STRING_CONST(304, aux_String_10, "into different generic subtype");
-            CHECK_REF(305, target, target_Refman)
-            LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error2(node, node_Refman, node_Dynamic, aux_String_9, aux_String_9_Refman, self->name, self->name_Refman, aux_String_10, aux_String_10_Refman, target->name, target->name_Refman);
-            CHECK(301)
+            TEST_ASSERT(305, node != NULL && node_Refman->value != NULL)
+            INIT_STRING_CONST(307, aux_String_10, "cannot assign generic subtype");
+            CHECK_REF(308, self, self_Refman)
+            INIT_STRING_CONST(309, aux_String_11, "into different generic subtype");
+            CHECK_REF(310, target, target_Refman)
+            LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error2(node, node_Refman, node_Dynamic, aux_String_10, aux_String_10_Refman, self->name, self->name_Refman, aux_String_11, aux_String_11_Refman, target->name, target->name_Refman);
+            CHECK(306)
         }
     }
     LUMI_err = tl5_compiler_M_access_is_owner(target_access, &(aux_Bool_7));
-    CHECK(306)
-    CHECK_REF(307, target, target_Refman)
-    CHECK_REF(307, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(307, target, target_Refman)
-    CHECK_REF(306, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(306, self, self_Refman)
+    CHECK(311)
+    CHECK_REF(312, target, target_Refman)
+    CHECK_REF(312, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(312, target, target_Refman)
+    CHECK_REF(311, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(311, self, self_Refman)
     if (((((void*)self->type_data == tl5_compiler_M_glob->type_string) && ((void*)target->type_data == tl5_compiler_M_glob->type_array)) && (target->parameters != NULL && target->parameters_Refman->value != NULL)) && (! aux_Bool_7)) {
-        CHECK_REF(309, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(309, target, target_Refman)
-        CHECK_REF(309, target->parameters, target->parameters_Refman)
-        CHECK_REF(309, target->parameters->first, target->parameters->first_Refman)
-        CHECK_REF(309, target->parameters->first->item, target->parameters->first->item_Refman)
+        CHECK_REF(314, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(314, target, target_Refman)
+        CHECK_REF(314, target->parameters, target->parameters_Refman)
+        CHECK_REF(314, target->parameters->first, target->parameters->first_Refman)
+        CHECK_REF(314, target->parameters->first->item, target->parameters->first->item_Refman)
         if ((void*)((tl5_compiler_M_TypeInstance*)(target->parameters->first->item))->type_data == tl5_compiler_M_glob->type_char) {
             goto LUMI_cleanup;
         }
@@ -35160,32 +35192,32 @@ Returncode tl5_compiler_M_TypeInstance_check_assign_to(tl5_compiler_M_TypeInstan
     self_type_instance_Refman = self_Refman;
     LUMI_inc_ref(self_type_instance_Refman);
     while (true) {
-        CHECK_REF(314, target, target_Refman)
-        CHECK_REF(315, self_type_instance, self_type_instance_Refman)
+        CHECK_REF(319, target, target_Refman)
+        CHECK_REF(320, self_type_instance, self_type_instance_Refman)
         LUMI_err = tl5_compiler_M_TypeData_is_same(target->type_data, target->type_data_Refman, target->type_data_Dynamic, self_type_instance->type_data, self_type_instance->type_data_Refman, self_type_instance->type_data_Dynamic, &(aux_Bool_8));
-        CHECK(314)
+        CHECK(319)
         if (!(! aux_Bool_8)) break;
-        CHECK_REF(316, self_type_instance, self_type_instance_Refman)
-        CHECK_REF(316, self_type_instance->type_data, self_type_instance->type_data_Refman)
+        CHECK_REF(321, self_type_instance, self_type_instance_Refman)
+        CHECK_REF(321, self_type_instance->type_data, self_type_instance->type_data_Refman)
         if (! (self_type_instance->type_data->base_type != NULL && self_type_instance->type_data->base_type_Refman->value != NULL)) {
-            TEST_ASSERT(317, node != NULL && node_Refman->value != NULL)
-            INIT_STRING_CONST(319, aux_String_11, "cannot assign");
-            CHECK_REF(320, self, self_Refman)
-            CHECK_REF(320, self->type_data, self->type_data_Refman)
-            INIT_STRING_CONST(321, aux_String_12, "into");
-            CHECK_REF(322, target, target_Refman)
-            CHECK_REF(322, target->type_data, target->type_data_Refman)
-            LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error2(node, node_Refman, node_Dynamic, aux_String_11, aux_String_11_Refman, self->type_data->name, self->type_data->name_Refman, aux_String_12, aux_String_12_Refman, target->type_data->name, target->type_data->name_Refman);
-            CHECK(318)
+            TEST_ASSERT(322, node != NULL && node_Refman->value != NULL)
+            INIT_STRING_CONST(324, aux_String_12, "cannot assign");
+            CHECK_REF(325, self, self_Refman)
+            CHECK_REF(325, self->type_data, self->type_data_Refman)
+            INIT_STRING_CONST(326, aux_String_13, "into");
+            CHECK_REF(327, target, target_Refman)
+            CHECK_REF(327, target->type_data, target->type_data_Refman)
+            LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error2(node, node_Refman, node_Dynamic, aux_String_12, aux_String_12_Refman, self->type_data->name, self->type_data->name_Refman, aux_String_13, aux_String_13_Refman, target->type_data->name, target->type_data->name_Refman);
+            CHECK(323)
         }
         prev_base_type_instance = base_type_instance;
         prev_base_type_instance_Refman = base_type_instance_Refman;
         base_type_instance = NULL;
         base_type_instance_Refman = NULL;
-        CHECK_REF(324, self_type_instance, self_type_instance_Refman)
-        CHECK_REF(324, self_type_instance->type_data, self_type_instance->type_data_Refman)
+        CHECK_REF(329, self_type_instance, self_type_instance_Refman)
+        CHECK_REF(329, self_type_instance->type_data, self_type_instance->type_data_Refman)
         LUMI_err = tl5_compiler_M_TypeInstance_new_replace_params_extended(self_type_instance->type_data->base_type, self_type_instance->type_data->base_type_Refman, self_type_instance, self_type_instance_Refman, false, &(base_type_instance), &(base_type_instance_Refman));
-        CHECK(324)
+        CHECK(329)
         aux_Ref_Manager = self_type_instance_Refman;
         self_type_instance_Refman = base_type_instance_Refman;
         LUMI_inc_ref(self_type_instance_Refman);
@@ -35194,36 +35226,37 @@ Returncode tl5_compiler_M_TypeInstance_check_assign_to(tl5_compiler_M_TypeInstan
         self_type_instance = base_type_instance;
         *bases += 1;
     }
-    CHECK_REF(329, target, target_Refman)
-    CHECK_REF(329, self, self_Refman)
+    CHECK_REF(334, target, target_Refman)
+    CHECK_REF(334, self, self_Refman)
     if (self->conditional && (! target->conditional)) {
-        TEST_ASSERT(330, node != NULL && node_Refman->value != NULL)
-        INIT_STRING_CONST(332, aux_String_13, "assigning conditional into non-conditional type");
-        CHECK_REF(333, target, target_Refman)
-        CHECK_REF(333, target->type_data, target->type_data_Refman)
-        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(node, node_Refman, node_Dynamic, aux_String_13, aux_String_13_Refman, target->type_data->name, target->type_data->name_Refman);
-        CHECK(331)
-    }
-    CHECK_REF(335, self, self_Refman)
-    if (self->arguments != NULL && self->arguments_Refman->value != NULL) {
-        CHECK_REF(336, self, self_Refman)
-        CHECK_REF(336, target, target_Refman)
-        LUMI_err = tl5_compiler_M_FunctionArguments_check_same_as(self->arguments, self->arguments_Refman, self->arguments_Dynamic, target->arguments, target->arguments_Refman, target->arguments_Dynamic, node != NULL && node_Refman->value != NULL);
+        TEST_ASSERT(335, node != NULL && node_Refman->value != NULL)
+        INIT_STRING_CONST(337, aux_String_14, "assigning conditional into non-conditional type");
+        CHECK_REF(338, target, target_Refman)
+        CHECK_REF(338, target->type_data, target->type_data_Refman)
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(node, node_Refman, node_Dynamic, aux_String_14, aux_String_14_Refman, target->type_data->name, target->type_data->name_Refman);
         CHECK(336)
     }
-    CHECK_REF(338, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(338, target, target_Refman)
-    CHECK_REF(338, target, target_Refman)
-    CHECK_REF(338, target->type_data, target->type_data_Refman)
+    CHECK_REF(340, self, self_Refman)
+    if (self->arguments != NULL && self->arguments_Refman->value != NULL) {
+        CHECK_REF(341, self, self_Refman)
+        CHECK_REF(341, target, target_Refman)
+        LUMI_err = tl5_compiler_M_FunctionArguments_check_same_as(self->arguments, self->arguments_Refman, self->arguments_Dynamic, target->arguments, target->arguments_Refman, target->arguments_Dynamic, node != NULL && node_Refman->value != NULL);
+        CHECK(341)
+    }
+    CHECK_REF(343, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(343, target, target_Refman)
+    CHECK_REF(343, target, target_Refman)
+    CHECK_REF(343, target->type_data, target->type_data_Refman)
     if (target->type_data->is_primitive || ((void*)target->type_data == tl5_compiler_M_glob->type_array)) {
         LUMI_err = tl5_compiler_M_TypeInstance_check_sub_equal(self_type_instance, self_type_instance_Refman, target, target_Refman, node, node_Refman, node_Dynamic);
-        CHECK(339)
+        CHECK(344)
     }
     else {
             LUMI_err = tl5_compiler_M_TypeInstance_check_sub_assign_to(self_type_instance, self_type_instance_Refman, target, target_Refman, node, node_Refman, node_Dynamic);
-            CHECK(341)
+            CHECK(346)
         }
 LUMI_cleanup:
+    LUMI_var_dec_ref(aux_String_14_Refman);
     LUMI_var_dec_ref(aux_String_13_Refman);
     LUMI_var_dec_ref(aux_String_12_Refman);
     LUMI_var_dec_ref(aux_String_11_Refman);
@@ -35274,21 +35307,21 @@ Returncode tl5_compiler_M_TypeInstance_check_sub_assign_to(tl5_compiler_M_TypeIn
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(target_Refman);
     LUMI_inc_ref(node_Refman);
-    CHECK_REF(345, target, target_Refman)
+    CHECK_REF(350, target, target_Refman)
     if (! (target->parameters != NULL && target->parameters_Refman->value != NULL)) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(347, target, target_Refman)
-    INIT_VAR(347, target_iter)
+    CHECK_REF(352, target, target_Refman)
+    INIT_VAR(352, target_iter)
     LUMI_err = tl5_compiler_M_ListIterator_new(target_iter, target_iter_Refman, target->parameters, target->parameters_Refman);
-    CHECK(347)
+    CHECK(352)
     LUMI_err = tl5_compiler_M_ListIterator_get(target_iter, target_iter_Refman, (void*)&(aux_TypeInstance_0), &(aux_TypeInstance_0_Refman), &dynamic_Void);
-    CHECK(348)
+    CHECK(353)
     LUMI_err = tl5_compiler_M_TypeInstance_check_has_subytpe(self, self_Refman, aux_TypeInstance_0, aux_TypeInstance_0_Refman, node, node_Refman, node_Dynamic);
-    CHECK(348)
-    CHECK_REF(349, self, self_Refman)
+    CHECK(353)
+    CHECK_REF(354, self, self_Refman)
     LUMI_err = tl5_compiler_M_List_iter(self->parameters, self->parameters_Refman, &(aux_ListIterator_0), &(aux_ListIterator_0_Refman));
-    CHECK(349)
+    CHECK(354)
     aux_Ref_Manager = aux_ListIterator_1_Refman;
     aux_ListIterator_1_Refman = aux_ListIterator_0_Refman;
     LUMI_inc_ref(aux_ListIterator_1_Refman);
@@ -35298,21 +35331,21 @@ Returncode tl5_compiler_M_TypeInstance_check_sub_assign_to(tl5_compiler_M_TypeIn
     while (true) {
         Bool my_sub_type_Has = false;
         LUMI_err = tl5_compiler_M_ListIterator_has(aux_ListIterator_1, aux_ListIterator_1_Refman, &(my_sub_type_Has));
-        CHECK(349)
+        CHECK(354)
         if (!my_sub_type_Has) break;
         LUMI_err = tl5_compiler_M_ListIterator_get(aux_ListIterator_1, aux_ListIterator_1_Refman, (void*)&(my_sub_type), &(my_sub_type_Refman), &dynamic_Void);
-        CHECK(349)
+        CHECK(354)
         LUMI_err = tl5_compiler_M_ListIterator_has(target_iter, target_iter_Refman, &(aux_Bool_0));
-        CHECK(350)
+        CHECK(355)
         if (!(aux_Bool_0)) break;
         LUMI_err = tl5_compiler_M_ListIterator_get(target_iter, target_iter_Refman, (void*)&(aux_TypeInstance_1), &(aux_TypeInstance_1_Refman), &dynamic_Void);
-        CHECK(351)
-        LUMI_err = tl5_compiler_M_TypeInstance_check_assign_to(my_sub_type, my_sub_type_Refman, tl5_compiler_M_Access_VAR, aux_TypeInstance_1, aux_TypeInstance_1_Refman, tl5_compiler_M_Access_VAR, node, node_Refman, node_Dynamic, &(aux_Int_0));
-        CHECK(351)
-        LUMI_err = tl5_compiler_M_ListIterator_next(target_iter, target_iter_Refman);
         CHECK(356)
+        LUMI_err = tl5_compiler_M_TypeInstance_check_assign_to(my_sub_type, my_sub_type_Refman, tl5_compiler_M_Access_VAR, aux_TypeInstance_1, aux_TypeInstance_1_Refman, tl5_compiler_M_Access_VAR, node, node_Refman, node_Dynamic, &(aux_Int_0));
+        CHECK(356)
+        LUMI_err = tl5_compiler_M_ListIterator_next(target_iter, target_iter_Refman);
+        CHECK(361)
         LUMI_err = tl5_compiler_M_ListIterator_next(aux_ListIterator_1, aux_ListIterator_1_Refman);
-        CHECK(349)
+        CHECK(354)
     }
     aux_Ref_Manager = aux_ListIterator_1_Refman;
     aux_ListIterator_1_Refman = NULL;
@@ -35349,17 +35382,17 @@ Returncode tl5_compiler_M_TypeInstance_check_has_subytpe(tl5_compiler_M_TypeInst
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(target_sub_type_Refman);
     LUMI_inc_ref(node_Refman);
-    CHECK_REF(360, self, self_Refman)
+    CHECK_REF(365, self, self_Refman)
     if (! (self->parameters != NULL && self->parameters_Refman->value != NULL)) {
-        TEST_ASSERT(361, node != NULL && node_Refman->value != NULL)
-        INIT_STRING_CONST(363, aux_String_0, "cannot assign type");
-        CHECK_REF(364, self, self_Refman)
-        CHECK_REF(364, self->type_data, self->type_data_Refman)
-        INIT_STRING_CONST(365, aux_String_1, "with no parameter into same type with parameter");
-        CHECK_REF(366, target_sub_type, target_sub_type_Refman)
-        CHECK_REF(366, target_sub_type->type_data, target_sub_type->type_data_Refman)
+        TEST_ASSERT(366, node != NULL && node_Refman->value != NULL)
+        INIT_STRING_CONST(368, aux_String_0, "cannot assign type");
+        CHECK_REF(369, self, self_Refman)
+        CHECK_REF(369, self->type_data, self->type_data_Refman)
+        INIT_STRING_CONST(370, aux_String_1, "with no parameter into same type with parameter");
+        CHECK_REF(371, target_sub_type, target_sub_type_Refman)
+        CHECK_REF(371, target_sub_type->type_data, target_sub_type->type_data_Refman)
         LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error2(node, node_Refman, node_Dynamic, aux_String_0, aux_String_0_Refman, self->type_data->name, self->type_data->name_Refman, aux_String_1, aux_String_1_Refman, target_sub_type->type_data->name, target_sub_type->type_data->name_Refman);
-        CHECK(362)
+        CHECK(367)
     }
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_1_Refman);
@@ -35388,31 +35421,31 @@ Returncode tl5_compiler_M_TypeInstance_check_equal(tl5_compiler_M_TypeInstance* 
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(other_Refman);
     LUMI_inc_ref(node_Refman);
-    CHECK_REF(369, other, other_Refman)
-    CHECK_REF(369, self, self_Refman)
+    CHECK_REF(374, other, other_Refman)
+    CHECK_REF(374, self, self_Refman)
     if ((void*)self->type_data != other->type_data) {
-        TEST_ASSERT(370, node != NULL && node_Refman->value != NULL)
-        INIT_STRING_CONST(372, aux_String_0, "non matching types");
-        CHECK_REF(373, self, self_Refman)
-        CHECK_REF(373, self->type_data, self->type_data_Refman)
-        INIT_STRING_CONST(374, aux_String_1, "and");
-        CHECK_REF(375, other, other_Refman)
-        CHECK_REF(375, other->type_data, other->type_data_Refman)
+        TEST_ASSERT(375, node != NULL && node_Refman->value != NULL)
+        INIT_STRING_CONST(377, aux_String_0, "non matching types");
+        CHECK_REF(378, self, self_Refman)
+        CHECK_REF(378, self->type_data, self->type_data_Refman)
+        INIT_STRING_CONST(379, aux_String_1, "and");
+        CHECK_REF(380, other, other_Refman)
+        CHECK_REF(380, other->type_data, other->type_data_Refman)
         LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error2(node, node_Refman, node_Dynamic, aux_String_0, aux_String_0_Refman, self->type_data->name, self->type_data->name_Refman, aux_String_1, aux_String_1_Refman, other->type_data->name, other->type_data->name_Refman);
-        CHECK(371)
+        CHECK(376)
     }
-    CHECK_REF(376, other, other_Refman)
-    CHECK_REF(376, self, self_Refman)
+    CHECK_REF(381, other, other_Refman)
+    CHECK_REF(381, self, self_Refman)
     if (self->conditional != other->conditional) {
-        TEST_ASSERT(377, node != NULL && node_Refman->value != NULL)
-        INIT_STRING_CONST(379, aux_String_2, "conditionals not matching in type");
-        CHECK_REF(380, self, self_Refman)
-        CHECK_REF(380, self->type_data, self->type_data_Refman)
+        TEST_ASSERT(382, node != NULL && node_Refman->value != NULL)
+        INIT_STRING_CONST(384, aux_String_2, "conditionals not matching in type");
+        CHECK_REF(385, self, self_Refman)
+        CHECK_REF(385, self->type_data, self->type_data_Refman)
         LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(node, node_Refman, node_Dynamic, aux_String_2, aux_String_2_Refman, self->type_data->name, self->type_data->name_Refman);
-        CHECK(378)
+        CHECK(383)
     }
     LUMI_err = tl5_compiler_M_TypeInstance_check_sub_equal(self, self_Refman, other, other_Refman, node, node_Refman, node_Dynamic);
-    CHECK(381)
+    CHECK(386)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_2_Refman);
     LUMI_var_dec_ref(aux_String_1_Refman);
@@ -35453,21 +35486,21 @@ Returncode tl5_compiler_M_TypeInstance_check_sub_equal(tl5_compiler_M_TypeInstan
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(target_Refman);
     LUMI_inc_ref(node_Refman);
-    CHECK_REF(384, target, target_Refman)
+    CHECK_REF(389, target, target_Refman)
     if (! (target->parameters != NULL && target->parameters_Refman->value != NULL)) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(386, target, target_Refman)
-    INIT_VAR(386, target_iter)
+    CHECK_REF(391, target, target_Refman)
+    INIT_VAR(391, target_iter)
     LUMI_err = tl5_compiler_M_ListIterator_new(target_iter, target_iter_Refman, target->parameters, target->parameters_Refman);
-    CHECK(386)
+    CHECK(391)
     LUMI_err = tl5_compiler_M_ListIterator_get(target_iter, target_iter_Refman, (void*)&(aux_TypeInstance_0), &(aux_TypeInstance_0_Refman), &dynamic_Void);
-    CHECK(387)
+    CHECK(392)
     LUMI_err = tl5_compiler_M_TypeInstance_check_has_subytpe(self, self_Refman, aux_TypeInstance_0, aux_TypeInstance_0_Refman, node, node_Refman, node_Dynamic);
-    CHECK(387)
-    CHECK_REF(388, self, self_Refman)
+    CHECK(392)
+    CHECK_REF(393, self, self_Refman)
     LUMI_err = tl5_compiler_M_List_iter(self->parameters, self->parameters_Refman, &(aux_ListIterator_0), &(aux_ListIterator_0_Refman));
-    CHECK(388)
+    CHECK(393)
     aux_Ref_Manager = aux_ListIterator_1_Refman;
     aux_ListIterator_1_Refman = aux_ListIterator_0_Refman;
     LUMI_inc_ref(aux_ListIterator_1_Refman);
@@ -35477,34 +35510,34 @@ Returncode tl5_compiler_M_TypeInstance_check_sub_equal(tl5_compiler_M_TypeInstan
     while (true) {
         Bool my_sub_type_Has = false;
         LUMI_err = tl5_compiler_M_ListIterator_has(aux_ListIterator_1, aux_ListIterator_1_Refman, &(my_sub_type_Has));
-        CHECK(388)
+        CHECK(393)
         if (!my_sub_type_Has) break;
         LUMI_err = tl5_compiler_M_ListIterator_get(aux_ListIterator_1, aux_ListIterator_1_Refman, (void*)&(my_sub_type), &(my_sub_type_Refman), &dynamic_Void);
-        CHECK(388)
+        CHECK(393)
         LUMI_err = tl5_compiler_M_ListIterator_has(target_iter, target_iter_Refman, &(aux_Bool_0));
-        CHECK(389)
+        CHECK(394)
         if (!(aux_Bool_0)) break;
         LUMI_err = tl5_compiler_M_ListIterator_get(target_iter, target_iter_Refman, (void*)&(target_sub_type), &(target_sub_type_Refman), &dynamic_Void);
-        CHECK(391)
-        CHECK_REF(392, target_sub_type, target_sub_type_Refman)
-        CHECK_REF(392, my_sub_type, my_sub_type_Refman)
+        CHECK(396)
+        CHECK_REF(397, target_sub_type, target_sub_type_Refman)
+        CHECK_REF(397, my_sub_type, my_sub_type_Refman)
         if ((void*)my_sub_type->type_data != target_sub_type->type_data) {
-            TEST_ASSERT(393, node != NULL && node_Refman->value != NULL)
-            INIT_STRING_CONST(395, aux_String_0, "non matching subtypes");
-            CHECK_REF(396, my_sub_type, my_sub_type_Refman)
-            CHECK_REF(396, my_sub_type->type_data, my_sub_type->type_data_Refman)
-            INIT_STRING_CONST(397, aux_String_1, "and");
-            CHECK_REF(398, target_sub_type, target_sub_type_Refman)
-            CHECK_REF(398, target_sub_type->type_data, target_sub_type->type_data_Refman)
+            TEST_ASSERT(398, node != NULL && node_Refman->value != NULL)
+            INIT_STRING_CONST(400, aux_String_0, "non matching subtypes");
+            CHECK_REF(401, my_sub_type, my_sub_type_Refman)
+            CHECK_REF(401, my_sub_type->type_data, my_sub_type->type_data_Refman)
+            INIT_STRING_CONST(402, aux_String_1, "and");
+            CHECK_REF(403, target_sub_type, target_sub_type_Refman)
+            CHECK_REF(403, target_sub_type->type_data, target_sub_type->type_data_Refman)
             LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error2(node, node_Refman, node_Dynamic, aux_String_0, aux_String_0_Refman, my_sub_type->type_data->name, my_sub_type->type_data->name_Refman, aux_String_1, aux_String_1_Refman, target_sub_type->type_data->name, target_sub_type->type_data->name_Refman);
-            CHECK(394)
+            CHECK(399)
         }
         LUMI_err = tl5_compiler_M_TypeInstance_check_sub_equal(my_sub_type, my_sub_type_Refman, target_sub_type, target_sub_type_Refman, node, node_Refman, node_Dynamic);
-        CHECK(399)
+        CHECK(404)
         LUMI_err = tl5_compiler_M_ListIterator_next(target_iter, target_iter_Refman);
-        CHECK(400)
+        CHECK(405)
         LUMI_err = tl5_compiler_M_ListIterator_next(aux_ListIterator_1, aux_ListIterator_1_Refman);
-        CHECK(388)
+        CHECK(393)
     }
     aux_Ref_Manager = aux_ListIterator_1_Refman;
     aux_ListIterator_1_Refman = NULL;
@@ -35542,34 +35575,34 @@ Returncode tl5_compiler_M_TypeInstance_check_sequence(tl5_compiler_M_TypeInstanc
     Ref_Manager* aux_String_1_Refman = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(node_Refman);
-    CHECK_REF(404, self, self_Refman)
-    CHECK_REF(404, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(404, self, self_Refman)
-    CHECK_REF(403, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(403, self, self_Refman)
+    CHECK_REF(409, self, self_Refman)
+    CHECK_REF(409, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(409, self, self_Refman)
+    CHECK_REF(408, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(408, self, self_Refman)
     if ((((void*)self->type_data == tl5_compiler_M_glob->type_array) || ((void*)self->type_data == tl5_compiler_M_glob->type_string)) && (! (self->length != NULL && self->length_Refman->value != NULL))) {
-        TEST_ASSERT(405, node != NULL && node_Refman->value != NULL)
-        INIT_STRING_CONST(406, aux_String_0, "missing length for sequence");
+        TEST_ASSERT(410, node != NULL && node_Refman->value != NULL)
+        INIT_STRING_CONST(411, aux_String_0, "missing length for sequence");
         LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error_msg(node, node_Refman, node_Dynamic, aux_String_0, aux_String_0_Refman);
-        CHECK(406)
+        CHECK(411)
     }
-    CHECK_REF(407, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(407, self, self_Refman)
+    CHECK_REF(412, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(412, self, self_Refman)
     if ((void*)self->type_data == tl5_compiler_M_glob->type_array) {
-        CHECK_REF(409, self, self_Refman)
-        CHECK_REF(409, self->parameters, self->parameters_Refman)
-        CHECK_REF(409, self->parameters->first, self->parameters->first_Refman)
-        CHECK_REF(409, self->parameters->first->item, self->parameters->first->item_Refman)
-        CHECK_REF(408, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(408, self, self_Refman)
-        CHECK_REF(408, self->parameters, self->parameters_Refman)
-        CHECK_REF(408, self->parameters->first, self->parameters->first_Refman)
-        CHECK_REF(408, self->parameters->first->item, self->parameters->first->item_Refman)
+        CHECK_REF(414, self, self_Refman)
+        CHECK_REF(414, self->parameters, self->parameters_Refman)
+        CHECK_REF(414, self->parameters->first, self->parameters->first_Refman)
+        CHECK_REF(414, self->parameters->first->item, self->parameters->first->item_Refman)
+        CHECK_REF(413, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(413, self, self_Refman)
+        CHECK_REF(413, self->parameters, self->parameters_Refman)
+        CHECK_REF(413, self->parameters->first, self->parameters->first_Refman)
+        CHECK_REF(413, self->parameters->first->item, self->parameters->first->item_Refman)
         if (((void*)((tl5_compiler_M_TypeInstance*)(self->parameters->first->item))->type_data == tl5_compiler_M_glob->type_string) && (! (((tl5_compiler_M_TypeInstance*)(self->parameters->first->item))->length != NULL && ((tl5_compiler_M_TypeInstance*)(self->parameters->first->item))->length_Refman->value != NULL))) {
-            TEST_ASSERT(410, node != NULL && node_Refman->value != NULL)
-            INIT_STRING_CONST(411, aux_String_1, "missing length for sequence");
+            TEST_ASSERT(415, node != NULL && node_Refman->value != NULL)
+            INIT_STRING_CONST(416, aux_String_1, "missing length for sequence");
             LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error_msg(node, node_Refman, node_Dynamic, aux_String_1, aux_String_1_Refman);
-            CHECK(411)
+            CHECK(416)
         }
     }
 LUMI_cleanup:
@@ -35596,24 +35629,24 @@ Returncode tl5_compiler_M_TypeInstance_get_array_data_type_depth(tl5_compiler_M_
     *data_type = self;
     *depth = 0;
     while (true) {
-        CHECK_REF(418, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(418, *data_type, (*data_type_Refman))
+        CHECK_REF(423, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(423, *data_type, (*data_type_Refman))
         if (!((void*)(*data_type)->type_data == tl5_compiler_M_glob->type_array)) break;
-        CHECK_REF(419, *data_type, (*data_type_Refman))
+        CHECK_REF(424, *data_type, (*data_type_Refman))
         if (!((*data_type)->parameters != NULL && (*data_type)->parameters_Refman->value != NULL)) break;
-        CHECK_REF(420, *data_type, (*data_type_Refman))
-        CHECK_REF(420, (*data_type)->parameters, (*data_type)->parameters_Refman)
-        CHECK_REF(420, (*data_type)->parameters->first, (*data_type)->parameters->first_Refman)
+        CHECK_REF(425, *data_type, (*data_type_Refman))
+        CHECK_REF(425, (*data_type)->parameters, (*data_type)->parameters_Refman)
+        CHECK_REF(425, (*data_type)->parameters->first, (*data_type)->parameters->first_Refman)
         aux_Ref_Manager = *data_type_Refman;
         *data_type_Refman = (*data_type)->parameters->first->item_Refman;
         LUMI_inc_ref(*data_type_Refman);
         LUMI_dec_ref(aux_Ref_Manager);
         aux_Ref_Manager = NULL;
         *data_type = (*data_type)->parameters->first->item;
-        CHECK_REF(422, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(422, *data_type, (*data_type_Refman))
-        CHECK_REF(421, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(421, *data_type, (*data_type_Refman))
+        CHECK_REF(427, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(427, *data_type, (*data_type_Refman))
+        CHECK_REF(426, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(426, *data_type, (*data_type_Refman))
         if (!(((void*)(*data_type)->type_data == tl5_compiler_M_glob->type_array) || ((void*)(*data_type)->type_data == tl5_compiler_M_glob->type_string))) break;
         *depth += 1;
     }
@@ -35631,7 +35664,7 @@ Returncode tl5_compiler_M_TypeInstance_new_replace_params(tl5_compiler_M_TypeIns
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(actual_params_Refman);
     LUMI_err = tl5_compiler_M_TypeInstance_new_replace_params_extended(self, self_Refman, actual_params, actual_params_Refman, true, &(*type_instance), &(*type_instance_Refman));
-    CHECK(429)
+    CHECK(434)
 LUMI_cleanup:
     LUMI_dec_ref(actual_params_Refman);
     LUMI_dec_ref(self_Refman);
@@ -35647,10 +35680,10 @@ Returncode tl5_compiler_M_TypeInstance_new_replace_params_extended(tl5_compiler_
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(actual_params_Refman);
     LUMI_err = tl5_compiler_M_TypeInstance_copy_new(self, self_Refman, &(*type_instance), &(*type_instance_Refman));
-    CHECK(435)
+    CHECK(440)
     if ((*type_instance) != NULL && (*type_instance_Refman)->value != NULL) {
         LUMI_err = tl5_compiler_M_TypeInstance_replace_type_parameters(*type_instance, *type_instance_Refman, actual_params, actual_params_Refman, replace_bases);
-        CHECK(437)
+        CHECK(442)
     }
 LUMI_cleanup:
     LUMI_dec_ref(actual_params_Refman);
@@ -35692,30 +35725,30 @@ Returncode tl5_compiler_M_TypeInstance_replace_type_parameters(tl5_compiler_M_Ty
     if (! (actual_params != NULL && actual_params_Refman->value != NULL)) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(444, actual_params, actual_params_Refman)
-    CHECK_REF(444, actual_params->type_data, actual_params->type_data_Refman)
-    if (replace_bases && (actual_params->type_data->base_type != NULL && actual_params->type_data->base_type_Refman->value != NULL)) {
-        CHECK_REF(446, actual_params, actual_params_Refman)
-        CHECK_REF(446, actual_params->type_data, actual_params->type_data_Refman)
-        LUMI_err = tl5_compiler_M_TypeInstance_new_replace_params_extended(actual_params->type_data->base_type, actual_params->type_data->base_type_Refman, actual_params, actual_params_Refman, false, &(base_type), &(base_type_Refman));
-        CHECK(446)
-        LUMI_err = tl5_compiler_M_TypeInstance_replace_type_parameters(self, self_Refman, base_type, base_type_Refman, true);
-        CHECK(448)
-    }
-    CHECK_REF(450, actual_params, actual_params_Refman)
-    CHECK_REF(450, actual_params->type_data, actual_params->type_data_Refman)
     CHECK_REF(449, actual_params, actual_params_Refman)
-    CHECK_REF(449, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(449, self, self_Refman)
-    if ((((void*)self->type_data == tl5_compiler_M_glob->type_generic) && (actual_params->parameters != NULL && actual_params->parameters_Refman->value != NULL)) && (actual_params->type_data->parameters != NULL && actual_params->type_data->parameters_Refman->value != NULL)) {
-        CHECK_REF(452, actual_params, actual_params_Refman)
-        CHECK_REF(452, actual_params->type_data, actual_params->type_data_Refman)
-        INIT_VAR(451, dec_iter)
-        LUMI_err = tl5_compiler_M_ListIterator_new(dec_iter, dec_iter_Refman, actual_params->type_data->parameters, actual_params->type_data->parameters_Refman);
+    CHECK_REF(449, actual_params->type_data, actual_params->type_data_Refman)
+    if (replace_bases && (actual_params->type_data->base_type != NULL && actual_params->type_data->base_type_Refman->value != NULL)) {
+        CHECK_REF(451, actual_params, actual_params_Refman)
+        CHECK_REF(451, actual_params->type_data, actual_params->type_data_Refman)
+        LUMI_err = tl5_compiler_M_TypeInstance_new_replace_params_extended(actual_params->type_data->base_type, actual_params->type_data->base_type_Refman, actual_params, actual_params_Refman, false, &(base_type), &(base_type_Refman));
         CHECK(451)
-        CHECK_REF(453, actual_params, actual_params_Refman)
-        LUMI_err = tl5_compiler_M_List_iter(actual_params->parameters, actual_params->parameters_Refman, &(aux_ListIterator_0), &(aux_ListIterator_0_Refman));
+        LUMI_err = tl5_compiler_M_TypeInstance_replace_type_parameters(self, self_Refman, base_type, base_type_Refman, true);
         CHECK(453)
+    }
+    CHECK_REF(455, actual_params, actual_params_Refman)
+    CHECK_REF(455, actual_params->type_data, actual_params->type_data_Refman)
+    CHECK_REF(454, actual_params, actual_params_Refman)
+    CHECK_REF(454, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(454, self, self_Refman)
+    if ((((void*)self->type_data == tl5_compiler_M_glob->type_generic) && (actual_params->parameters != NULL && actual_params->parameters_Refman->value != NULL)) && (actual_params->type_data->parameters != NULL && actual_params->type_data->parameters_Refman->value != NULL)) {
+        CHECK_REF(457, actual_params, actual_params_Refman)
+        CHECK_REF(457, actual_params->type_data, actual_params->type_data_Refman)
+        INIT_VAR(456, dec_iter)
+        LUMI_err = tl5_compiler_M_ListIterator_new(dec_iter, dec_iter_Refman, actual_params->type_data->parameters, actual_params->type_data->parameters_Refman);
+        CHECK(456)
+        CHECK_REF(458, actual_params, actual_params_Refman)
+        LUMI_err = tl5_compiler_M_List_iter(actual_params->parameters, actual_params->parameters_Refman, &(aux_ListIterator_0), &(aux_ListIterator_0_Refman));
+        CHECK(458)
         aux_Ref_Manager = aux_ListIterator_1_Refman;
         aux_ListIterator_1_Refman = aux_ListIterator_0_Refman;
         LUMI_inc_ref(aux_ListIterator_1_Refman);
@@ -35725,31 +35758,31 @@ Returncode tl5_compiler_M_TypeInstance_replace_type_parameters(tl5_compiler_M_Ty
         while (true) {
             Bool inst_param_Has = false;
             LUMI_err = tl5_compiler_M_ListIterator_has(aux_ListIterator_1, aux_ListIterator_1_Refman, &(inst_param_Has));
-            CHECK(453)
+            CHECK(458)
             if (!inst_param_Has) break;
             LUMI_err = tl5_compiler_M_ListIterator_get(aux_ListIterator_1, aux_ListIterator_1_Refman, (void*)&(inst_param), &(inst_param_Refman), &dynamic_Void);
-            CHECK(453)
+            CHECK(458)
             LUMI_err = tl5_compiler_M_ListIterator_has(dec_iter, dec_iter_Refman, &(aux_Bool_0));
-            CHECK(454)
+            CHECK(459)
             if (!(aux_Bool_0)) break;
             LUMI_err = tl5_compiler_M_ListIterator_get(dec_iter, dec_iter_Refman, (void*)&(aux_String_0), &(aux_String_0_Refman), &dynamic_Void);
-            CHECK(455)
-            CHECK_REF(455, self, self_Refman)
+            CHECK(460)
+            CHECK_REF(460, self, self_Refman)
             LUMI_err = String_equal(aux_String_0, aux_String_0_Refman, self->name, self->name_Refman, &(aux_Bool_1));
-            CHECK(455)
+            CHECK(460)
             if (aux_Bool_1) {
-                CHECK_REF(456, self, self_Refman)
+                CHECK_REF(461, self, self_Refman)
                 conditional = self->conditional;
                 LUMI_err = tl5_compiler_M_TypeInstance_copy(inst_param, inst_param_Refman, self, self_Refman);
-                CHECK(457)
-                CHECK_REF(458, self, self_Refman)
+                CHECK(462)
+                CHECK_REF(463, self, self_Refman)
                 self->conditional = conditional;
                 break;
             }
             LUMI_err = tl5_compiler_M_ListIterator_next(dec_iter, dec_iter_Refman);
-            CHECK(460)
+            CHECK(465)
             LUMI_err = tl5_compiler_M_ListIterator_next(aux_ListIterator_1, aux_ListIterator_1_Refman);
-            CHECK(453)
+            CHECK(458)
         }
         aux_Ref_Manager = aux_ListIterator_1_Refman;
         aux_ListIterator_1_Refman = NULL;
@@ -35758,11 +35791,11 @@ Returncode tl5_compiler_M_TypeInstance_replace_type_parameters(tl5_compiler_M_Ty
         aux_Ref_Manager = NULL;
         aux_ListIterator_1 = NULL;
     }
-    CHECK_REF(461, self, self_Refman)
+    CHECK_REF(466, self, self_Refman)
     if (self->parameters != NULL && self->parameters_Refman->value != NULL) {
-        CHECK_REF(462, self, self_Refman)
+        CHECK_REF(467, self, self_Refman)
         LUMI_err = tl5_compiler_M_List_iter(self->parameters, self->parameters_Refman, &(aux_ListIterator_2), &(aux_ListIterator_2_Refman));
-        CHECK(462)
+        CHECK(467)
         aux_Ref_Manager = aux_ListIterator_3_Refman;
         aux_ListIterator_3_Refman = aux_ListIterator_2_Refman;
         LUMI_inc_ref(aux_ListIterator_3_Refman);
@@ -35772,14 +35805,14 @@ Returncode tl5_compiler_M_TypeInstance_replace_type_parameters(tl5_compiler_M_Ty
         while (true) {
             Bool parameter_Has = false;
             LUMI_err = tl5_compiler_M_ListIterator_has(aux_ListIterator_3, aux_ListIterator_3_Refman, &(parameter_Has));
-            CHECK(462)
+            CHECK(467)
             if (!parameter_Has) break;
             LUMI_err = tl5_compiler_M_ListIterator_get(aux_ListIterator_3, aux_ListIterator_3_Refman, (void*)&(parameter), &(parameter_Refman), &dynamic_Void);
-            CHECK(462)
+            CHECK(467)
             LUMI_err = tl5_compiler_M_TypeInstance_replace_type_parameters(parameter, parameter_Refman, actual_params, actual_params_Refman, replace_bases);
-            CHECK(463)
+            CHECK(468)
             LUMI_err = tl5_compiler_M_ListIterator_next(aux_ListIterator_3, aux_ListIterator_3_Refman);
-            CHECK(462)
+            CHECK(467)
         }
         aux_Ref_Manager = aux_ListIterator_3_Refman;
         aux_ListIterator_3_Refman = NULL;
@@ -35819,31 +35852,31 @@ Returncode tl5_compiler_M_TypeInstance_write_cname(tl5_compiler_M_TypeInstance* 
     String* aux_String_1 = NULL;
     Ref_Manager* aux_String_1_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(467, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(467, self, self_Refman)
+    CHECK_REF(472, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(472, self, self_Refman)
     if ((void*)self->type_data == tl5_compiler_M_glob->type_pointer) {
-        CHECK_REF(468, self, self_Refman)
+        CHECK_REF(473, self, self_Refman)
         if (self->parameters != NULL && self->parameters_Refman->value != NULL) {
-            CHECK_REF(469, self, self_Refman)
-            CHECK_REF(469, self->parameters, self->parameters_Refman)
-            CHECK_REF(469, self->parameters->first, self->parameters->first_Refman)
+            CHECK_REF(474, self, self_Refman)
+            CHECK_REF(474, self->parameters, self->parameters_Refman)
+            CHECK_REF(474, self->parameters->first, self->parameters->first_Refman)
             LUMI_err = tl5_compiler_M_TypeInstance_write_cname(self->parameters->first->item, self->parameters->first->item_Refman);
-            CHECK(469)
-            INIT_STRING_CONST(470, aux_String_0, "*");
+            CHECK(474)
+            INIT_STRING_CONST(475, aux_String_0, "*");
             LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-            CHECK(470)
+            CHECK(475)
         }
         else {
-                INIT_STRING_CONST(472, aux_String_1, "void*");
+                INIT_STRING_CONST(477, aux_String_1, "void*");
                 LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-                CHECK(472)
+                CHECK(477)
             }
     }
     else {
-            CHECK_REF(474, self, self_Refman)
-            if (self->type_data_Dynamic == NULL) RAISE(474, empty_object)
+            CHECK_REF(479, self, self_Refman)
+            if (self->type_data_Dynamic == NULL) RAISE(479, empty_object)
             LUMI_err = self->type_data_Dynamic->write_cname(self->type_data, self->type_data_Refman, self->type_data_Dynamic);
-            CHECK(474)
+            CHECK(479)
         }
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_1_Refman);
@@ -41902,13 +41935,16 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_analyze(tl5_compiler_M_SyntaxTreeVa
     String aux_String_4_Var = {0};
     String* aux_String_4 = NULL;
     Ref_Manager* aux_String_4_Refman = NULL;
-    Bool aux_Bool_2 = 0;
     String aux_String_5_Var = {0};
     String* aux_String_5 = NULL;
     Ref_Manager* aux_String_5_Refman = NULL;
+    Bool aux_Bool_2 = 0;
     String aux_String_6_Var = {0};
     String* aux_String_6 = NULL;
     Ref_Manager* aux_String_6_Refman = NULL;
+    String aux_String_7_Var = {0};
+    String* aux_String_7 = NULL;
+    Ref_Manager* aux_String_7_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
     CHECK_REF(122, self, self_Refman)
@@ -41972,72 +42008,85 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_analyze(tl5_compiler_M_SyntaxTreeVa
         LUMI_err = tl5_compiler_M_TypeInstance_check_sequence(self->type_instance, self->type_instance_Refman, &(self->_base._base), self_Refman, &(self_Dynamic->_base._base));
         CHECK(141)
     }
-    CHECK_REF(143, self, self_Refman)
-    CHECK_REF(143, self, self_Refman)
     CHECK_REF(142, self, self_Refman)
     CHECK_REF(142, self, self_Refman)
-    if (((! (self->_base.parent != NULL && self->_base.parent_Refman->value != NULL)) && (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL))) && ((self->access == tl5_compiler_M_Access_USER) || (self->access == tl5_compiler_M_Access_TEMP))) {
-        INIT_STRING_CONST(145, aux_String_3, "global variables cannot have access");
-        CHECK_REF(146, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(146, self, self_Refman)
-        CHECK_REF(146, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
-        if ((self->access) < 0 || (self->access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(146, slice_index)
-        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_3, aux_String_3_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + self->access, tl5_compiler_M_glob->access_names_Refman);
-        CHECK(144)
-    }
-    CHECK_REF(147, self, self_Refman)
-    if (self->parent_type != NULL && self->parent_type_Refman->value != NULL) {
-        CHECK_REF(148, self, self_Refman)
-        CHECK_REF(148, self, self_Refman)
+    if ((! (self->_base.parent != NULL && self->_base.parent_Refman->value != NULL)) && (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL))) {
+        CHECK_REF(143, self, self_Refman)
+        CHECK_REF(143, self, self_Refman)
         if ((self->access == tl5_compiler_M_Access_USER) || (self->access == tl5_compiler_M_Access_TEMP)) {
-            INIT_STRING_CONST(150, aux_String_4, "fields cannot have access");
-            CHECK_REF(151, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-            CHECK_REF(151, self, self_Refman)
-            CHECK_REF(151, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
-            if ((self->access) < 0 || (self->access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(151, slice_index)
-            LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_4, aux_String_4_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + self->access, tl5_compiler_M_glob->access_names_Refman);
-            CHECK(149)
+            INIT_STRING_CONST(145, aux_String_3, "global variables cannot have access");
+            CHECK_REF(146, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+            CHECK_REF(146, self, self_Refman)
+            CHECK_REF(146, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
+            if ((self->access) < 0 || (self->access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(146, slice_index)
+            LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_3, aux_String_3_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + self->access, tl5_compiler_M_glob->access_names_Refman);
+            CHECK(144)
         }
-        CHECK_REF(154, self, self_Refman)
-        CHECK_REF(154, self->parent_type, self->parent_type_Refman)
-        CHECK_REF(153, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(149, self, self_Refman)
+        CHECK_REF(148, self, self_Refman)
+        CHECK_REF(148, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(147, self, self_Refman)
+        CHECK_REF(147, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(147, self->type_instance->type_data, self->type_instance->type_data_Refman)
+        if (((! self->type_instance->type_data->is_primitive) && (! self->type_instance->conditional)) && (! self->is_initialized)) {
+            INIT_STRING_CONST(151, aux_String_4, "non-conditional global variable not initialized");
+            LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error_msg(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_4, aux_String_4_Refman);
+            CHECK(150)
+        }
+    }
+    CHECK_REF(152, self, self_Refman)
+    if (self->parent_type != NULL && self->parent_type_Refman->value != NULL) {
         CHECK_REF(153, self, self_Refman)
-        CHECK_REF(153, self->type_instance, self->type_instance_Refman)
-        CHECK_REF(152, self, self_Refman)
-        CHECK_REF(152, self->type_instance, self->type_instance_Refman)
-        CHECK_REF(152, self->type_instance->type_data, self->type_instance->type_data_Refman)
+        CHECK_REF(153, self, self_Refman)
+        if ((self->access == tl5_compiler_M_Access_USER) || (self->access == tl5_compiler_M_Access_TEMP)) {
+            INIT_STRING_CONST(155, aux_String_5, "fields cannot have access");
+            CHECK_REF(156, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+            CHECK_REF(156, self, self_Refman)
+            CHECK_REF(156, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
+            if ((self->access) < 0 || (self->access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(156, slice_index)
+            LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_5, aux_String_5_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + self->access, tl5_compiler_M_glob->access_names_Refman);
+            CHECK(154)
+        }
+        CHECK_REF(159, self, self_Refman)
+        CHECK_REF(159, self->parent_type, self->parent_type_Refman)
+        CHECK_REF(158, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(158, self, self_Refman)
+        CHECK_REF(158, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(157, self, self_Refman)
+        CHECK_REF(157, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(157, self->type_instance->type_data, self->type_instance->type_data_Refman)
         if (((! self->type_instance->type_data->is_primitive) || ((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_func)) && (! (self->parent_type->constructor != NULL && self->parent_type->constructor_Refman->value != NULL))) {
-            CHECK_REF(155, self, self_Refman)
+            CHECK_REF(160, self, self_Refman)
             LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_2));
-            CHECK(155)
+            CHECK(160)
             if (aux_Bool_2) {
-                CHECK_REF(156, self, self_Refman)
-                CHECK_REF(156, self->type_instance, self->type_instance_Refman)
-                CHECK_REF(156, self->type_instance->type_data, self->type_instance->type_data_Refman)
+                CHECK_REF(161, self, self_Refman)
+                CHECK_REF(161, self->type_instance, self->type_instance_Refman)
+                CHECK_REF(161, self->type_instance->type_data, self->type_instance->type_data_Refman)
                 if (self->type_instance->type_data->constructor != NULL && self->type_instance->type_data->constructor_Refman->value != NULL) {
-                    INIT_STRING_CONST(159, aux_String_5, "variable with constructor in type without constructor");
-                    CHECK_REF(160, self, self_Refman)
-                    CHECK_REF(160, self->parent_type, self->parent_type_Refman)
-                    LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_5, aux_String_5_Refman, self->parent_type->name, self->parent_type->name_Refman);
-                    CHECK(157)
+                    INIT_STRING_CONST(164, aux_String_6, "variable with constructor in type without constructor");
+                    CHECK_REF(165, self, self_Refman)
+                    CHECK_REF(165, self->parent_type, self->parent_type_Refman)
+                    LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_6, aux_String_6_Refman, self->parent_type->name, self->parent_type->name_Refman);
+                    CHECK(162)
                 }
             }
             else {
-                    CHECK_REF(161, self, self_Refman)
-                    CHECK_REF(161, self->type_instance, self->type_instance_Refman)
+                    CHECK_REF(166, self, self_Refman)
+                    CHECK_REF(166, self->type_instance, self->type_instance_Refman)
                     if (! self->type_instance->conditional) {
-                        INIT_STRING_CONST(164, aux_String_6, "non-conditional reference in type without constructor");
-                        CHECK_REF(165, self, self_Refman)
-                        CHECK_REF(165, self->parent_type, self->parent_type_Refman)
-                        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_6, aux_String_6_Refman, self->parent_type->name, self->parent_type->name_Refman);
-                        CHECK(162)
+                        INIT_STRING_CONST(169, aux_String_7, "non-conditional reference in type without constructor");
+                        CHECK_REF(170, self, self_Refman)
+                        CHECK_REF(170, self->parent_type, self->parent_type_Refman)
+                        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_7, aux_String_7_Refman, self->parent_type->name, self->parent_type->name_Refman);
+                        CHECK(167)
                     }
                 }
         }
     }
-    CHECK_REF(166, self, self_Refman)
+    CHECK_REF(171, self, self_Refman)
     if (self->my_module != NULL && self->my_module_Refman->value != NULL) {
-        CHECK_REF(167, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(172, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
         aux_Ref_Manager = tl5_compiler_M_glob->current_module_Refman;
         tl5_compiler_M_glob->current_module_Refman = NULL;
         LUMI_inc_ref(tl5_compiler_M_glob->current_module_Refman);
@@ -42046,6 +42095,7 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_analyze(tl5_compiler_M_SyntaxTreeVa
         tl5_compiler_M_glob->current_module = NULL;
     }
 LUMI_cleanup:
+    LUMI_var_dec_ref(aux_String_7_Refman);
     LUMI_var_dec_ref(aux_String_6_Refman);
     LUMI_var_dec_ref(aux_String_5_Refman);
     LUMI_var_dec_ref(aux_String_4_Refman);
@@ -42079,7 +42129,7 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_check_memory(tl5_compiler_M_SyntaxT
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(refs_Refman);
     LUMI_err = tl5_compiler_M_ReferenceMemoryList_add(refs, refs_Refman, self, self_Refman, self_Dynamic);
-    CHECK(173)
+    CHECK(178)
 LUMI_cleanup:
     LUMI_dec_ref(refs_Refman);
     LUMI_dec_ref(self_Refman);
@@ -42093,15 +42143,15 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_SyntaxTreeVariable_write_cname(tl5_compiler_M_SyntaxTreeVariable* self, Ref_Manager* self_Refman, tl5_compiler_M_SyntaxTreeVariable_Dynamic* self_Dynamic) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(176, self, self_Refman)
+    CHECK_REF(181, self, self_Refman)
     if (self->my_module != NULL && self->my_module_Refman->value != NULL) {
-        CHECK_REF(177, self, self_Refman)
+        CHECK_REF(182, self, self_Refman)
         LUMI_err = tl5_compiler_M_ModuleMembers_write_prefix(self->my_module, self->my_module_Refman);
-        CHECK(177)
+        CHECK(182)
     }
-    CHECK_REF(178, self, self_Refman)
+    CHECK_REF(183, self, self_Refman)
     LUMI_err = tl5_compiler_M_write_cname(self->name, self->name_Refman);
-    CHECK(178)
+    CHECK(183)
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
     return LUMI_err;
@@ -42136,118 +42186,118 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write(tl5_compiler_M_SyntaxTreeVari
     Bool aux_Bool_2 = 0;
     Bool aux_Bool_3 = 0;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(181, self, self_Refman)
-    CHECK_REF(181, self, self_Refman)
+    CHECK_REF(186, self, self_Refman)
+    CHECK_REF(186, self, self_Refman)
     if ((self->_base.parent != NULL && self->_base.parent_Refman->value != NULL) || (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-        CHECK(182)
+        CHECK(187)
     }
     else {
-            CHECK_REF(183, self, self_Refman)
+            CHECK_REF(188, self, self_Refman)
             if (! self->is_native) {
-                INIT_STRING_CONST(184, aux_String_0, "\n");
+                INIT_STRING_CONST(189, aux_String_0, "\n");
                 LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-                CHECK(184)
+                CHECK(189)
             }
         }
-    CHECK_REF(187, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(187, self, self_Refman)
-    CHECK_REF(187, self->type_instance, self->type_instance_Refman)
-    CHECK_REF(186, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(186, self, self_Refman)
-    CHECK_REF(186, self->type_instance, self->type_instance_Refman)
-    if (((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_array) || ((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_string)) {
-        LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_sequence(self, self_Refman, self_Dynamic);
-        CHECK(188)
-        goto LUMI_cleanup;
-    }
+    CHECK_REF(192, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     CHECK_REF(192, self, self_Refman)
-    CHECK_REF(192, self, self_Refman)
-    LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_0));
-    CHECK(191)
+    CHECK_REF(192, self->type_instance, self->type_instance_Refman)
+    CHECK_REF(191, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     CHECK_REF(191, self, self_Refman)
     CHECK_REF(191, self->type_instance, self->type_instance_Refman)
-    CHECK_REF(191, self->type_instance->type_data, self->type_instance->type_data_Refman)
+    if (((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_array) || ((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_string)) {
+        LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_sequence(self, self_Refman, self_Dynamic);
+        CHECK(193)
+        goto LUMI_cleanup;
+    }
+    CHECK_REF(197, self, self_Refman)
+    CHECK_REF(197, self, self_Refman)
+    LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_0));
+    CHECK(196)
+    CHECK_REF(196, self, self_Refman)
+    CHECK_REF(196, self->type_instance, self->type_instance_Refman)
+    CHECK_REF(196, self->type_instance->type_data, self->type_instance->type_data_Refman)
     if (((! self->type_instance->type_data->is_primitive) && aux_Bool_0) && (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL))) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_var(self, self_Refman, self_Dynamic);
-        CHECK(193)
+        CHECK(198)
     }
-    CHECK_REF(198, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(198, self, self_Refman)
-    CHECK_REF(198, self->type_instance, self->type_instance_Refman)
+    CHECK_REF(203, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(203, self, self_Refman)
+    CHECK_REF(203, self->type_instance, self->type_instance_Refman)
     if ((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_func) {
-        CHECK_REF(199, self, self_Refman)
-        CHECK_REF(199, self->type_instance, self->type_instance_Refman)
-        CHECK_REF(199, self, self_Refman)
+        CHECK_REF(204, self, self_Refman)
+        CHECK_REF(204, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(204, self, self_Refman)
         LUMI_err = tl5_compiler_M_FunctionArguments_write_pointer(self->type_instance->arguments, self->type_instance->arguments_Refman, self->type_instance->arguments_Dynamic, self->name, self->name_Refman);
-        CHECK(199)
+        CHECK(204)
     }
     else {
-            CHECK_REF(201, self, self_Refman)
+            CHECK_REF(206, self, self_Refman)
             LUMI_err = tl5_compiler_M_TypeInstance_write_cname(self->type_instance, self->type_instance_Refman);
-            CHECK(201)
-            CHECK_REF(204, self, self_Refman)
-            LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_1));
-            CHECK(202)
-            CHECK_REF(203, self, self_Refman)
-            CHECK_REF(202, self, self_Refman)
-            CHECK_REF(202, self->type_instance, self->type_instance_Refman)
-            CHECK_REF(202, self->type_instance->type_data, self->type_instance->type_data_Refman)
-            if ((! self->type_instance->type_data->is_primitive) && (! ((self->parent_type != NULL && self->parent_type_Refman->value != NULL) && aux_Bool_1))) {
-            INIT_STRING_CONST(205, aux_String_1, "*");
-            LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-            CHECK(205)
-        }
-            INIT_STRING_CONST(206, aux_String_2, " ");
-            LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
             CHECK(206)
-            if (self_Dynamic == NULL) RAISE(207, empty_object)
-            LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+            CHECK_REF(209, self, self_Refman)
+            LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_1));
             CHECK(207)
+            CHECK_REF(208, self, self_Refman)
+            CHECK_REF(207, self, self_Refman)
+            CHECK_REF(207, self->type_instance, self->type_instance_Refman)
+            CHECK_REF(207, self->type_instance->type_data, self->type_instance->type_data_Refman)
+            if ((! self->type_instance->type_data->is_primitive) && (! ((self->parent_type != NULL && self->parent_type_Refman->value != NULL) && aux_Bool_1))) {
+            INIT_STRING_CONST(210, aux_String_1, "*");
+            LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
+            CHECK(210)
         }
-    CHECK_REF(209, self, self_Refman)
-    CHECK_REF(209, self, self_Refman)
+            INIT_STRING_CONST(211, aux_String_2, " ");
+            LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
+            CHECK(211)
+            if (self_Dynamic == NULL) RAISE(212, empty_object)
+            LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+            CHECK(212)
+        }
+    CHECK_REF(214, self, self_Refman)
+    CHECK_REF(214, self, self_Refman)
     if ((! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) && (! self->is_native)) {
-        CHECK_REF(212, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(212, self, self_Refman)
-        CHECK_REF(212, self->type_instance, self->type_instance_Refman)
-        CHECK_REF(211, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(211, self, self_Refman)
-        CHECK_REF(211, self->type_instance, self->type_instance_Refman)
-        CHECK_REF(210, self, self_Refman)
-        CHECK_REF(210, self->type_instance, self->type_instance_Refman)
-        CHECK_REF(210, self->type_instance->type_data, self->type_instance->type_data_Refman)
+        CHECK_REF(217, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(217, self, self_Refman)
+        CHECK_REF(217, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(216, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(216, self, self_Refman)
+        CHECK_REF(216, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(215, self, self_Refman)
+        CHECK_REF(215, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(215, self->type_instance->type_data, self->type_instance->type_data_Refman)
         if ((self->type_instance->type_data->is_primitive && ((void*)self->type_instance->type_data != tl5_compiler_M_glob->type_func)) && ((void*)self->type_instance->type_data != tl5_compiler_M_glob->type_ref)) {
-            INIT_STRING_CONST(213, aux_String_3, " = 0");
+            INIT_STRING_CONST(218, aux_String_3, " = 0");
             LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
-            CHECK(213)
+            CHECK(218)
         }
         else {
-                INIT_STRING_CONST(215, aux_String_4, " = NULL");
+                INIT_STRING_CONST(220, aux_String_4, " = NULL");
                 LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
-                CHECK(215)
+                CHECK(220)
             }
     }
-    INIT_STRING_CONST(217, aux_String_5, ";\n");
+    INIT_STRING_CONST(222, aux_String_5, ";\n");
     LUMI_err = tl5_compiler_M_write(aux_String_5, aux_String_5_Refman);
-    CHECK(217)
-    CHECK_REF(219, self, self_Refman)
+    CHECK(222)
+    CHECK_REF(224, self, self_Refman)
     LUMI_err = tl5_compiler_M_access_has_refman(self->access, &(aux_Bool_2));
-    CHECK(219)
+    CHECK(224)
     if (aux_Bool_2) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_refman(self, self_Refman, self_Dynamic);
-        CHECK(220)
+        CHECK(225)
     }
-    CHECK_REF(223, self, self_Refman)
+    CHECK_REF(228, self, self_Refman)
     LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_3));
-    CHECK(222)
-    CHECK_REF(223, self, self_Refman)
-    CHECK_REF(222, self, self_Refman)
-    CHECK_REF(222, self->type_instance, self->type_instance_Refman)
-    CHECK_REF(222, self->type_instance->type_data, self->type_instance->type_data_Refman)
+    CHECK(227)
+    CHECK_REF(228, self, self_Refman)
+    CHECK_REF(227, self, self_Refman)
+    CHECK_REF(227, self->type_instance, self->type_instance_Refman)
+    CHECK_REF(227, self->type_instance->type_data, self->type_instance->type_data_Refman)
     if (self->type_instance->type_data->is_dynamic && (! ((self->parent_type != NULL && self->parent_type_Refman->value != NULL) && aux_Bool_3))) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_dynamic(self, self_Refman, self_Dynamic);
-        CHECK(224)
+        CHECK(229)
     }
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_5_Refman);
@@ -42384,280 +42434,280 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write_sequence(tl5_compiler_M_Synta
     Bool aux_Bool_1 = 0;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(232, self, self_Refman)
-    CHECK_REF(232, self, self_Refman)
+    CHECK_REF(237, self, self_Refman)
+    CHECK_REF(237, self, self_Refman)
     LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_0));
-    CHECK(231)
-    is_new_or_aux_var = aux_Bool_0 && self->is_create;
-    CHECK_REF(233, self, self_Refman)
-    is_new_var = is_new_or_aux_var && (! self->is_aux);
-    CHECK_REF(236, self, self_Refman)
-    LUMI_err = tl5_compiler_M_TypeInstance_get_array_data_type_depth(self->type_instance, self->type_instance_Refman, &(data_type), &(data_type_Refman), &(sequence_depth));
     CHECK(236)
-    CHECK_REF(238, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(238, data_type, data_type_Refman)
+    is_new_or_aux_var = aux_Bool_0 && self->is_create;
+    CHECK_REF(238, self, self_Refman)
+    is_new_var = is_new_or_aux_var && (! self->is_aux);
+    CHECK_REF(241, self, self_Refman)
+    LUMI_err = tl5_compiler_M_TypeInstance_get_array_data_type_depth(self->type_instance, self->type_instance_Refman, &(data_type), &(data_type_Refman), &(sequence_depth));
+    CHECK(241)
+    CHECK_REF(243, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(243, data_type, data_type_Refman)
     if ((void*)data_type->type_data == tl5_compiler_M_glob->type_string) {
-        INIT_STRING_CONST(239, aux_String_0, "char");
+        INIT_STRING_CONST(244, aux_String_0, "char");
         LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-        CHECK(239)
+        CHECK(244)
     }
     else {
-            CHECK_REF(240, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-            CHECK_REF(240, data_type, data_type_Refman)
+            CHECK_REF(245, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+            CHECK_REF(245, data_type, data_type_Refman)
             if ((void*)data_type->type_data == tl5_compiler_M_glob->type_func) {
-                CHECK_REF(241, data_type, data_type_Refman)
+                CHECK_REF(246, data_type, data_type_Refman)
                 LUMI_err = tl5_compiler_M_FunctionArguments_write_pointer_start(data_type->arguments, data_type->arguments_Refman, data_type->arguments_Dynamic);
-                CHECK(241)
+                CHECK(246)
             }
             else {
                 LUMI_err = tl5_compiler_M_TypeInstance_write_cname(data_type, data_type_Refman);
-                CHECK(243)
+                CHECK(248)
             }
         }
     if (! is_new_var) {
-        INIT_STRING_CONST(245, aux_String_1, "*");
+        INIT_STRING_CONST(250, aux_String_1, "*");
         LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-        CHECK(245)
-    }
-    CHECK_REF(246, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(246, data_type, data_type_Refman)
-    if ((void*)data_type->type_data != tl5_compiler_M_glob->type_func) {
-        INIT_STRING_CONST(247, aux_String_2, " ");
-        LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-        CHECK(247)
-    }
-    if (self_Dynamic == NULL) RAISE(248, empty_object)
-    LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
-    CHECK(248)
-    if (is_new_var) {
-        INIT_STRING_CONST(250, aux_String_3, "[");
-        LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
         CHECK(250)
-        CHECK_REF(251, self, self_Refman)
+    }
+    CHECK_REF(251, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(251, data_type, data_type_Refman)
+    if ((void*)data_type->type_data != tl5_compiler_M_glob->type_func) {
+        INIT_STRING_CONST(252, aux_String_2, " ");
+        LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
+        CHECK(252)
+    }
+    if (self_Dynamic == NULL) RAISE(253, empty_object)
+    LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+    CHECK(253)
+    if (is_new_var) {
+        INIT_STRING_CONST(255, aux_String_3, "[");
+        LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
+        CHECK(255)
+        CHECK_REF(256, self, self_Refman)
         sequence_type = self->type_instance;
         sequence_type_Refman = self->type_instance_Refman;
         LUMI_inc_ref(sequence_type_Refman);
-        CHECK_REF(252, sequence_type, sequence_type_Refman)
-        if (sequence_type->length_Dynamic == NULL) RAISE(252, empty_object)
+        CHECK_REF(257, sequence_type, sequence_type_Refman)
+        if (sequence_type->length_Dynamic == NULL) RAISE(257, empty_object)
         LUMI_err = sequence_type->length_Dynamic->_base.write(&(sequence_type->length->_base), sequence_type->length_Refman, &(sequence_type->length_Dynamic->_base));
-        CHECK(252)
+        CHECK(257)
         for (_ = 0; _ < sequence_depth; ++_) {
-            CHECK_REF(254, sequence_type, sequence_type_Refman)
-            CHECK_REF(254, sequence_type->parameters, sequence_type->parameters_Refman)
-            CHECK_REF(254, sequence_type->parameters->first, sequence_type->parameters->first_Refman)
+            CHECK_REF(259, sequence_type, sequence_type_Refman)
+            CHECK_REF(259, sequence_type->parameters, sequence_type->parameters_Refman)
+            CHECK_REF(259, sequence_type->parameters->first, sequence_type->parameters->first_Refman)
             aux_Ref_Manager = sequence_type_Refman;
             sequence_type_Refman = sequence_type->parameters->first->item_Refman;
             LUMI_inc_ref(sequence_type_Refman);
             LUMI_dec_ref(aux_Ref_Manager);
             aux_Ref_Manager = NULL;
             sequence_type = sequence_type->parameters->first->item;
-            INIT_STRING_CONST(255, aux_String_4, " * ");
+            INIT_STRING_CONST(260, aux_String_4, " * ");
             LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
-            CHECK(255)
-            CHECK_REF(256, sequence_type, sequence_type_Refman)
-            if (sequence_type->length_Dynamic == NULL) RAISE(256, empty_object)
+            CHECK(260)
+            CHECK_REF(261, sequence_type, sequence_type_Refman)
+            if (sequence_type->length_Dynamic == NULL) RAISE(261, empty_object)
             LUMI_err = sequence_type->length_Dynamic->_base.write(&(sequence_type->length->_base), sequence_type->length_Refman, &(sequence_type->length_Dynamic->_base));
-            CHECK(256)
+            CHECK(261)
         }
-        INIT_STRING_CONST(257, aux_String_5, "]");
+        INIT_STRING_CONST(262, aux_String_5, "]");
         LUMI_err = tl5_compiler_M_write(aux_String_5, aux_String_5_Refman);
-        CHECK(257)
-    }
-    CHECK_REF(258, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(258, data_type, data_type_Refman)
-    if ((void*)data_type->type_data == tl5_compiler_M_glob->type_func) {
-        INIT_STRING_CONST(259, aux_String_6, ")");
-        LUMI_err = tl5_compiler_M_write(aux_String_6, aux_String_6_Refman);
-        CHECK(259)
-        CHECK_REF(260, data_type, data_type_Refman)
-        if (data_type->arguments_Dynamic == NULL) RAISE(260, empty_object)
-        LUMI_err = data_type->arguments_Dynamic->_base.write(&(data_type->arguments->_base), data_type->arguments_Refman, &(data_type->arguments_Dynamic->_base));
-        CHECK(260)
-    }
-    CHECK_REF(261, self, self_Refman)
-    if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
-        INIT_STRING_CONST(262, aux_String_7, " = ");
-        LUMI_err = tl5_compiler_M_write(aux_String_7, aux_String_7_Refman);
         CHECK(262)
+    }
+    CHECK_REF(263, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(263, data_type, data_type_Refman)
+    if ((void*)data_type->type_data == tl5_compiler_M_glob->type_func) {
+        INIT_STRING_CONST(264, aux_String_6, ")");
+        LUMI_err = tl5_compiler_M_write(aux_String_6, aux_String_6_Refman);
+        CHECK(264)
+        CHECK_REF(265, data_type, data_type_Refman)
+        if (data_type->arguments_Dynamic == NULL) RAISE(265, empty_object)
+        LUMI_err = data_type->arguments_Dynamic->_base.write(&(data_type->arguments->_base), data_type->arguments_Refman, &(data_type->arguments_Dynamic->_base));
+        CHECK(265)
+    }
+    CHECK_REF(266, self, self_Refman)
+    if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
+        INIT_STRING_CONST(267, aux_String_7, " = ");
+        LUMI_err = tl5_compiler_M_write(aux_String_7, aux_String_7_Refman);
+        CHECK(267)
         if (is_new_var) {
-            INIT_STRING_CONST(264, aux_String_8, "{0}");
+            INIT_STRING_CONST(269, aux_String_8, "{0}");
             LUMI_err = tl5_compiler_M_write(aux_String_8, aux_String_8_Refman);
-            CHECK(264)
+            CHECK(269)
         }
         else {
-                INIT_STRING_CONST(266, aux_String_9, "NULL");
+                INIT_STRING_CONST(271, aux_String_9, "NULL");
                 LUMI_err = tl5_compiler_M_write(aux_String_9, aux_String_9_Refman);
-                CHECK(266)
+                CHECK(271)
             }
     }
-    INIT_STRING_CONST(267, aux_String_10, ";\n");
+    INIT_STRING_CONST(272, aux_String_10, ";\n");
     LUMI_err = tl5_compiler_M_write(aux_String_10, aux_String_10_Refman);
-    CHECK(267)
+    CHECK(272)
     if (! is_new_var) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-        CHECK(272)
-        INIT_STRING_CONST(273, aux_String_11, "int");
+        CHECK(277)
+        INIT_STRING_CONST(278, aux_String_11, "int");
         LUMI_err = tl5_compiler_M_write(aux_String_11, aux_String_11_Refman);
-        CHECK(273)
-        INIT_STRING_CONST(274, aux_String_12, " ");
+        CHECK(278)
+        INIT_STRING_CONST(279, aux_String_12, " ");
         LUMI_err = tl5_compiler_M_write(aux_String_12, aux_String_12_Refman);
-        CHECK(274)
-        if (self_Dynamic == NULL) RAISE(275, empty_object)
+        CHECK(279)
+        if (self_Dynamic == NULL) RAISE(280, empty_object)
         LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
-        CHECK(275)
-        INIT_STRING_CONST(276, aux_String_13, "_");
+        CHECK(280)
+        INIT_STRING_CONST(281, aux_String_13, "_");
         LUMI_err = tl5_compiler_M_write(aux_String_13, aux_String_13_Refman);
-        CHECK(276)
-        CHECK_REF(277, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(277, self, self_Refman)
-        CHECK_REF(277, self->type_instance, self->type_instance_Refman)
+        CHECK(281)
+        CHECK_REF(282, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(282, self, self_Refman)
+        CHECK_REF(282, self->type_instance, self->type_instance_Refman)
         if ((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_string) {
-            INIT_STRING_CONST(278, aux_String_14, "Max_length");
+            INIT_STRING_CONST(283, aux_String_14, "Max_length");
             LUMI_err = tl5_compiler_M_write(aux_String_14, aux_String_14_Refman);
-            CHECK(278)
+            CHECK(283)
         }
         else {
-                INIT_STRING_CONST(280, aux_String_15, "Length");
+                INIT_STRING_CONST(285, aux_String_15, "Length");
                 LUMI_err = tl5_compiler_M_write(aux_String_15, aux_String_15_Refman);
-                CHECK(280)
+                CHECK(285)
             }
-        CHECK_REF(281, self, self_Refman)
+        CHECK_REF(286, self, self_Refman)
         if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
-            INIT_STRING_CONST(282, aux_String_16, " = 0");
+            INIT_STRING_CONST(287, aux_String_16, " = 0");
             LUMI_err = tl5_compiler_M_write(aux_String_16, aux_String_16_Refman);
-            CHECK(282)
+            CHECK(287)
         }
-        INIT_STRING_CONST(283, aux_String_17, ";\n");
+        INIT_STRING_CONST(288, aux_String_17, ";\n");
         LUMI_err = tl5_compiler_M_write(aux_String_17, aux_String_17_Refman);
-        CHECK(283)
+        CHECK(288)
         for (depth = 0; depth < sequence_depth; ++depth) {
             LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-            CHECK(287)
-            INIT_STRING_CONST(288, aux_String_18, "int ");
+            CHECK(292)
+            INIT_STRING_CONST(293, aux_String_18, "int ");
             LUMI_err = tl5_compiler_M_write(aux_String_18, aux_String_18_Refman);
-            CHECK(288)
-            if (self_Dynamic == NULL) RAISE(289, empty_object)
-            LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
-            CHECK(289)
-            LUMI_err = tl5_compiler_M_write_array_value_length(depth);
-            CHECK(290)
-            CHECK_REF(291, self, self_Refman)
-            if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
-                INIT_STRING_CONST(292, aux_String_19, " = 0");
-                LUMI_err = tl5_compiler_M_write(aux_String_19, aux_String_19_Refman);
-                CHECK(292)
-            }
-            INIT_STRING_CONST(293, aux_String_20, ";\n");
-            LUMI_err = tl5_compiler_M_write(aux_String_20, aux_String_20_Refman);
             CHECK(293)
+            if (self_Dynamic == NULL) RAISE(294, empty_object)
+            LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+            CHECK(294)
+            LUMI_err = tl5_compiler_M_write_array_value_length(depth);
+            CHECK(295)
+            CHECK_REF(296, self, self_Refman)
+            if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
+                INIT_STRING_CONST(297, aux_String_19, " = 0");
+                LUMI_err = tl5_compiler_M_write(aux_String_19, aux_String_19_Refman);
+                CHECK(297)
+            }
+            INIT_STRING_CONST(298, aux_String_20, ";\n");
+            LUMI_err = tl5_compiler_M_write(aux_String_20, aux_String_20_Refman);
+            CHECK(298)
         }
     }
-    CHECK_REF(295, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(295, data_type, data_type_Refman)
+    CHECK_REF(300, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(300, data_type, data_type_Refman)
     if ((void*)data_type->type_data == tl5_compiler_M_glob->type_string) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-        CHECK(300)
-        INIT_STRING_CONST(301, aux_String_21, "int");
-        LUMI_err = tl5_compiler_M_write(aux_String_21, aux_String_21_Refman);
-        CHECK(301)
-        if (! is_new_or_aux_var) {
-            INIT_STRING_CONST(303, aux_String_22, "*");
-            LUMI_err = tl5_compiler_M_write(aux_String_22, aux_String_22_Refman);
-            CHECK(303)
-        }
-        INIT_STRING_CONST(304, aux_String_23, " ");
-        LUMI_err = tl5_compiler_M_write(aux_String_23, aux_String_23_Refman);
-        CHECK(304)
-        if (self_Dynamic == NULL) RAISE(305, empty_object)
-        LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
         CHECK(305)
+        INIT_STRING_CONST(306, aux_String_21, "int");
+        LUMI_err = tl5_compiler_M_write(aux_String_21, aux_String_21_Refman);
+        CHECK(306)
+        if (! is_new_or_aux_var) {
+            INIT_STRING_CONST(308, aux_String_22, "*");
+            LUMI_err = tl5_compiler_M_write(aux_String_22, aux_String_22_Refman);
+            CHECK(308)
+        }
+        INIT_STRING_CONST(309, aux_String_23, " ");
+        LUMI_err = tl5_compiler_M_write(aux_String_23, aux_String_23_Refman);
+        CHECK(309)
+        if (self_Dynamic == NULL) RAISE(310, empty_object)
+        LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+        CHECK(310)
         if (sequence_depth > 0) {
-            INIT_STRING_CONST(307, aux_String_24, "_String_length");
+            INIT_STRING_CONST(312, aux_String_24, "_String_length");
             LUMI_err = tl5_compiler_M_write(aux_String_24, aux_String_24_Refman);
-            CHECK(307)
+            CHECK(312)
         }
         else {
-                INIT_STRING_CONST(309, aux_String_25, "_Length");
+                INIT_STRING_CONST(314, aux_String_25, "_Length");
                 LUMI_err = tl5_compiler_M_write(aux_String_25, aux_String_25_Refman);
-                CHECK(309)
+                CHECK(314)
             }
         if (is_new_or_aux_var) {
-            INIT_STRING_CONST(311, aux_String_26, "[");
+            INIT_STRING_CONST(316, aux_String_26, "[");
             LUMI_err = tl5_compiler_M_write(aux_String_26, aux_String_26_Refman);
-            CHECK(311)
+            CHECK(316)
             if (sequence_depth > 0) {
-                CHECK_REF(313, self, self_Refman)
+                CHECK_REF(318, self, self_Refman)
                 aux_Ref_Manager = sequence_type_Refman;
                 sequence_type_Refman = self->type_instance_Refman;
                 LUMI_inc_ref(sequence_type_Refman);
                 LUMI_dec_ref(aux_Ref_Manager);
                 aux_Ref_Manager = NULL;
                 sequence_type = self->type_instance;
-                CHECK_REF(314, sequence_type, sequence_type_Refman)
-                if (sequence_type->length_Dynamic == NULL) RAISE(314, empty_object)
+                CHECK_REF(319, sequence_type, sequence_type_Refman)
+                if (sequence_type->length_Dynamic == NULL) RAISE(319, empty_object)
                 LUMI_err = sequence_type->length_Dynamic->_base.write(&(sequence_type->length->_base), sequence_type->length_Refman, &(sequence_type->length_Dynamic->_base));
-                CHECK(314)
+                CHECK(319)
                 for (_ = 0; _ < sequence_depth - 1; ++_) {
-                    CHECK_REF(316, sequence_type, sequence_type_Refman)
-                    CHECK_REF(316, sequence_type->parameters, sequence_type->parameters_Refman)
-                    CHECK_REF(316, sequence_type->parameters->first, sequence_type->parameters->first_Refman)
+                    CHECK_REF(321, sequence_type, sequence_type_Refman)
+                    CHECK_REF(321, sequence_type->parameters, sequence_type->parameters_Refman)
+                    CHECK_REF(321, sequence_type->parameters->first, sequence_type->parameters->first_Refman)
                     aux_Ref_Manager = sequence_type_Refman;
                     sequence_type_Refman = sequence_type->parameters->first->item_Refman;
                     LUMI_inc_ref(sequence_type_Refman);
                     LUMI_dec_ref(aux_Ref_Manager);
                     aux_Ref_Manager = NULL;
                     sequence_type = sequence_type->parameters->first->item;
-                    INIT_STRING_CONST(317, aux_String_27, " * ");
+                    INIT_STRING_CONST(322, aux_String_27, " * ");
                     LUMI_err = tl5_compiler_M_write(aux_String_27, aux_String_27_Refman);
-                    CHECK(317)
-                    CHECK_REF(318, sequence_type, sequence_type_Refman)
-                    if (sequence_type->length_Dynamic == NULL) RAISE(318, empty_object)
+                    CHECK(322)
+                    CHECK_REF(323, sequence_type, sequence_type_Refman)
+                    if (sequence_type->length_Dynamic == NULL) RAISE(323, empty_object)
                     LUMI_err = sequence_type->length_Dynamic->_base.write(&(sequence_type->length->_base), sequence_type->length_Refman, &(sequence_type->length_Dynamic->_base));
-                    CHECK(318)
+                    CHECK(323)
                 }
             }
             else {
-                    INIT_STRING_CONST(320, aux_String_28, "1");
+                    INIT_STRING_CONST(325, aux_String_28, "1");
                     LUMI_err = tl5_compiler_M_write(aux_String_28, aux_String_28_Refman);
-                    CHECK(320)
+                    CHECK(325)
                 }
-            INIT_STRING_CONST(321, aux_String_29, "]");
+            INIT_STRING_CONST(326, aux_String_29, "]");
             LUMI_err = tl5_compiler_M_write(aux_String_29, aux_String_29_Refman);
-            CHECK(321)
+            CHECK(326)
         }
-        CHECK_REF(322, self, self_Refman)
+        CHECK_REF(327, self, self_Refman)
         if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
-            INIT_STRING_CONST(323, aux_String_30, " = ");
+            INIT_STRING_CONST(328, aux_String_30, " = ");
             LUMI_err = tl5_compiler_M_write(aux_String_30, aux_String_30_Refman);
-            CHECK(323)
+            CHECK(328)
             if (is_new_or_aux_var) {
-                INIT_STRING_CONST(325, aux_String_31, "{0}");
+                INIT_STRING_CONST(330, aux_String_31, "{0}");
                 LUMI_err = tl5_compiler_M_write(aux_String_31, aux_String_31_Refman);
-                CHECK(325)
+                CHECK(330)
             }
             else {
                     if (sequence_depth == 0) {
-                        INIT_STRING_CONST(327, aux_String_32, "&Lumi_empty_int");
+                        INIT_STRING_CONST(332, aux_String_32, "&Lumi_empty_int");
                         LUMI_err = tl5_compiler_M_write(aux_String_32, aux_String_32_Refman);
-                        CHECK(327)
+                        CHECK(332)
                     }
                     else {
-                        INIT_STRING_CONST(329, aux_String_33, "NULL");
+                        INIT_STRING_CONST(334, aux_String_33, "NULL");
                         LUMI_err = tl5_compiler_M_write(aux_String_33, aux_String_33_Refman);
-                        CHECK(329)
+                        CHECK(334)
                     }
                 }
         }
-        INIT_STRING_CONST(330, aux_String_34, ";\n");
+        INIT_STRING_CONST(335, aux_String_34, ";\n");
         LUMI_err = tl5_compiler_M_write(aux_String_34, aux_String_34_Refman);
-        CHECK(330)
+        CHECK(335)
     }
-    CHECK_REF(332, self, self_Refman)
+    CHECK_REF(337, self, self_Refman)
     LUMI_err = tl5_compiler_M_access_has_refman(self->access, &(aux_Bool_1));
-    CHECK(332)
+    CHECK(337)
     if (aux_Bool_1) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_refman(self, self_Refman, self_Dynamic);
-        CHECK(333)
+        CHECK(338)
     }
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_34_Refman);
@@ -42736,29 +42786,29 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write_var(tl5_compiler_M_SyntaxTree
     Ref_Manager* aux_String_5_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(337, self, self_Refman)
-    LUMI_err = tl5_compiler_M_TypeInstance_write_cname(self->type_instance, self->type_instance_Refman);
-    CHECK(337)
-    INIT_STRING_CONST(338, aux_String_0, " ");
-    LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(338)
-    if (self_Dynamic == NULL) RAISE(339, empty_object)
-    LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
-    CHECK(339)
-    INIT_STRING_CONST(340, aux_String_1, "_Var = {");
-    LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-    CHECK(340)
     CHECK_REF(342, self, self_Refman)
-    CHECK_REF(342, self->type_instance, self->type_instance_Refman)
+    LUMI_err = tl5_compiler_M_TypeInstance_write_cname(self->type_instance, self->type_instance_Refman);
+    CHECK(342)
+    INIT_STRING_CONST(343, aux_String_0, " ");
+    LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
+    CHECK(343)
+    if (self_Dynamic == NULL) RAISE(344, empty_object)
+    LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+    CHECK(344)
+    INIT_STRING_CONST(345, aux_String_1, "_Var = {");
+    LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
+    CHECK(345)
+    CHECK_REF(347, self, self_Refman)
+    CHECK_REF(347, self->type_instance, self->type_instance_Refman)
     type_data = self->type_instance->type_data;
     type_data_Refman = self->type_instance->type_data_Refman;
     LUMI_inc_ref(type_data_Refman);
     type_data_Dynamic = self->type_instance->type_data_Dynamic;
     while (true) {
-        CHECK_REF(344, type_data, type_data_Refman)
+        CHECK_REF(349, type_data, type_data_Refman)
         if (type_data->base_type != NULL && type_data->base_type_Refman->value != NULL) {
-            CHECK_REF(345, type_data, type_data_Refman)
-            CHECK_REF(345, type_data->base_type, type_data->base_type_Refman)
+            CHECK_REF(350, type_data, type_data_Refman)
+            CHECK_REF(350, type_data->base_type, type_data->base_type_Refman)
             aux_Ref_Manager = type_data_Refman;
             type_data_Refman = type_data->base_type->type_data_Refman;
             type_data_Dynamic = type_data->base_type->type_data_Dynamic;
@@ -42768,21 +42818,21 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write_var(tl5_compiler_M_SyntaxTree
             type_data = type_data->base_type->type_data;
         }
         else {
-                CHECK_REF(348, type_data, type_data_Refman)
-                CHECK_REF(348, type_data->_base._base.variables.first, type_data->_base._base.variables.first_Refman)
+                CHECK_REF(353, type_data, type_data_Refman)
+                CHECK_REF(353, type_data->_base._base.variables.first, type_data->_base._base.variables.first_Refman)
                 variable = type_data->_base._base.variables.first->item;
                 variable_Refman = type_data->_base._base.variables.first->item_Refman;
                 LUMI_inc_ref(variable_Refman);
                 variable_Dynamic = ((tl5_compiler_M_SyntaxTreeVariable_Dynamic*)(type_data->_base._base.variables.first->item_Dynamic));
-                CHECK_REF(350, variable, variable_Refman)
-                CHECK_REF(350, variable->type_instance, variable->type_instance_Refman)
-                CHECK_REF(350, variable->type_instance->type_data, variable->type_instance->type_data_Refman)
-                CHECK_REF(349, variable, variable_Refman)
+                CHECK_REF(355, variable, variable_Refman)
+                CHECK_REF(355, variable->type_instance, variable->type_instance_Refman)
+                CHECK_REF(355, variable->type_instance->type_data, variable->type_instance->type_data_Refman)
+                CHECK_REF(354, variable, variable_Refman)
                 LUMI_err = tl5_compiler_M_access_is_only_var(variable->access, &(aux_Bool_0));
-                CHECK(349)
+                CHECK(354)
                 if (aux_Bool_0 && (! variable->type_instance->type_data->is_primitive)) {
-                CHECK_REF(351, variable, variable_Refman)
-                CHECK_REF(351, variable->type_instance, variable->type_instance_Refman)
+                CHECK_REF(356, variable, variable_Refman)
+                CHECK_REF(356, variable->type_instance, variable->type_instance_Refman)
                 aux_Ref_Manager = type_data_Refman;
                 type_data_Refman = variable->type_instance->type_data_Refman;
                 type_data_Dynamic = variable->type_instance->type_data_Dynamic;
@@ -42796,23 +42846,23 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write_var(tl5_compiler_M_SyntaxTree
                 }
             }
         bases += 1;
-        INIT_STRING_CONST(355, aux_String_2, "{");
+        INIT_STRING_CONST(360, aux_String_2, "{");
         LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-        CHECK(355)
+        CHECK(360)
     }
-    INIT_STRING_CONST(356, aux_String_3, "0");
+    INIT_STRING_CONST(361, aux_String_3, "0");
     LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
-    CHECK(356)
+    CHECK(361)
     for (n = 0; n < bases; ++n) {
-        INIT_STRING_CONST(358, aux_String_4, "}");
+        INIT_STRING_CONST(363, aux_String_4, "}");
         LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
-        CHECK(358)
+        CHECK(363)
     }
-    INIT_STRING_CONST(359, aux_String_5, "};\n");
+    INIT_STRING_CONST(364, aux_String_5, "};\n");
     LUMI_err = tl5_compiler_M_write(aux_String_5, aux_String_5_Refman);
-    CHECK(359)
+    CHECK(364)
     LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-    CHECK(360)
+    CHECK(365)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_5_Refman);
     LUMI_var_dec_ref(aux_String_4_Refman);
@@ -42849,28 +42899,28 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write_refman(tl5_compiler_M_SyntaxT
     Ref_Manager* aux_String_4_Refman = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-    CHECK(363)
-    INIT_STRING_CONST(364, aux_String_0, "Ref_Manager*");
+    CHECK(368)
+    INIT_STRING_CONST(369, aux_String_0, "Ref_Manager*");
     LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(364)
-    INIT_STRING_CONST(365, aux_String_1, " ");
+    CHECK(369)
+    INIT_STRING_CONST(370, aux_String_1, " ");
     LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-    CHECK(365)
-    if (self_Dynamic == NULL) RAISE(366, empty_object)
-    LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
-    CHECK(366)
-    INIT_STRING_CONST(367, aux_String_2, "_Refman");
-    LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-    CHECK(367)
-    CHECK_REF(368, self, self_Refman)
-    if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
-        INIT_STRING_CONST(369, aux_String_3, " = NULL");
-        LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
-        CHECK(369)
-    }
-    INIT_STRING_CONST(370, aux_String_4, ";\n");
-    LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
     CHECK(370)
+    if (self_Dynamic == NULL) RAISE(371, empty_object)
+    LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+    CHECK(371)
+    INIT_STRING_CONST(372, aux_String_2, "_Refman");
+    LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
+    CHECK(372)
+    CHECK_REF(373, self, self_Refman)
+    if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
+        INIT_STRING_CONST(374, aux_String_3, " = NULL");
+        LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
+        CHECK(374)
+    }
+    INIT_STRING_CONST(375, aux_String_4, ";\n");
+    LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
+    CHECK(375)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_4_Refman);
     LUMI_var_dec_ref(aux_String_3_Refman);
@@ -42910,45 +42960,45 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write_dynamic(tl5_compiler_M_Syntax
     Ref_Manager* aux_String_6_Refman = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-    CHECK(374)
-    CHECK_REF(375, self, self_Refman)
+    CHECK(379)
+    CHECK_REF(380, self, self_Refman)
     LUMI_err = tl5_compiler_M_TypeInstance_write_cname(self->type_instance, self->type_instance_Refman);
-    CHECK(375)
-    INIT_STRING_CONST(376, aux_String_0, "_Dynamic* ");
+    CHECK(380)
+    INIT_STRING_CONST(381, aux_String_0, "_Dynamic* ");
     LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(376)
-    if (self_Dynamic == NULL) RAISE(377, empty_object)
+    CHECK(381)
+    if (self_Dynamic == NULL) RAISE(382, empty_object)
     LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
-    CHECK(377)
-    INIT_STRING_CONST(378, aux_String_1, "_Dynamic");
+    CHECK(382)
+    INIT_STRING_CONST(383, aux_String_1, "_Dynamic");
     LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-    CHECK(378)
-    CHECK_REF(379, self, self_Refman)
+    CHECK(383)
+    CHECK_REF(384, self, self_Refman)
     if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
-        INIT_STRING_CONST(380, aux_String_2, " = ");
+        INIT_STRING_CONST(385, aux_String_2, " = ");
         LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-        CHECK(380)
-        CHECK_REF(381, self, self_Refman)
+        CHECK(385)
+        CHECK_REF(386, self, self_Refman)
         if (self->is_create) {
-            INIT_STRING_CONST(382, aux_String_3, "&");
+            INIT_STRING_CONST(387, aux_String_3, "&");
             LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
-            CHECK(382)
-            CHECK_REF(383, self, self_Refman)
+            CHECK(387)
+            CHECK_REF(388, self, self_Refman)
             LUMI_err = tl5_compiler_M_TypeInstance_write_cname(self->type_instance, self->type_instance_Refman);
-            CHECK(383)
-            INIT_STRING_CONST(384, aux_String_4, "_dynamic");
+            CHECK(388)
+            INIT_STRING_CONST(389, aux_String_4, "_dynamic");
             LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
-            CHECK(384)
+            CHECK(389)
         }
         else {
-                INIT_STRING_CONST(386, aux_String_5, "NULL");
+                INIT_STRING_CONST(391, aux_String_5, "NULL");
                 LUMI_err = tl5_compiler_M_write(aux_String_5, aux_String_5_Refman);
-                CHECK(386)
+                CHECK(391)
             }
     }
-    INIT_STRING_CONST(387, aux_String_6, ";\n");
+    INIT_STRING_CONST(392, aux_String_6, ";\n");
     LUMI_err = tl5_compiler_M_write(aux_String_6, aux_String_6_Refman);
-    CHECK(387)
+    CHECK(392)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_6_Refman);
     LUMI_var_dec_ref(aux_String_5_Refman);
@@ -42968,17 +43018,17 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_SyntaxTreeVariable_write_spaces(tl5_compiler_M_SyntaxTreeVariable* self, Ref_Manager* self_Refman, tl5_compiler_M_SyntaxTreeVariable_Dynamic* self_Dynamic) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(390, self, self_Refman)
+    CHECK_REF(395, self, self_Refman)
     if (self->_base.parent != NULL && self->_base.parent_Refman->value != NULL) {
         LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(&(self->_base), self_Refman, &(self_Dynamic->_base));
-        CHECK(391)
+        CHECK(396)
     }
     else {
-            CHECK_REF(392, self, self_Refman)
+            CHECK_REF(397, self, self_Refman)
             if (self->parent_type != NULL && self->parent_type_Refman->value != NULL) {
-                CHECK_REF(393, self, self_Refman)
+                CHECK_REF(398, self, self_Refman)
                 LUMI_err = tl5_compiler_M_SyntaxTreeBranch_write_spaces(&(self->parent_type->_base._base), self->parent_type_Refman, &(self->parent_type_Dynamic->_base._base));
-                CHECK(393)
+                CHECK(398)
             }
         }
 LUMI_cleanup:
@@ -43137,9 +43187,9 @@ Returncode tl5_compiler_M_SyntaxTreeConstant_parse_new(tl5_compiler_M_SyntaxTree
     Ref_Manager* aux_SyntaxTreeConstant_1_Refman = NULL;
     tl5_compiler_M_SyntaxTreeConstant_Dynamic* aux_SyntaxTreeConstant_1_Dynamic = NULL;
     LUMI_inc_ref(self_Refman);
-    INIT_NEW(485, aux_SyntaxTreeConstant_0, LUMI_alloc(sizeof(tl5_compiler_M_SyntaxTreeConstant)));
+    INIT_NEW(490, aux_SyntaxTreeConstant_0, LUMI_alloc(sizeof(tl5_compiler_M_SyntaxTreeConstant)));
     LUMI_err = tl5_compiler_M_SyntaxTreeCode_new(&(aux_SyntaxTreeConstant_0->_base._base), aux_SyntaxTreeConstant_0_Refman, &(aux_SyntaxTreeConstant_0_Dynamic->_base._base), NULL, NULL, NULL);
-    CHECK(485)
+    CHECK(490)
     aux_SyntaxTreeConstant_1 = aux_SyntaxTreeConstant_0;
     aux_SyntaxTreeConstant_1_Refman = aux_SyntaxTreeConstant_0_Refman;
     aux_SyntaxTreeConstant_1_Dynamic = aux_SyntaxTreeConstant_0_Dynamic;
@@ -43155,7 +43205,7 @@ Returncode tl5_compiler_M_SyntaxTreeConstant_parse_new(tl5_compiler_M_SyntaxTree
     aux_SyntaxTreeConstant_1_Refman = NULL;
     aux_SyntaxTreeConstant_1_Dynamic = NULL;
     LUMI_err = tl5_compiler_M_SyntaxTreeConstant_parse(*constant, *constant_Refman, *constant_Dynamic);
-    CHECK(486)
+    CHECK(491)
 LUMI_cleanup:
     if (aux_SyntaxTreeConstant_1_Dynamic != NULL) aux_SyntaxTreeConstant_1_Dynamic->_base._base._base._del(aux_SyntaxTreeConstant_1);
     LUMI_owner_dec_ref(aux_SyntaxTreeConstant_1_Refman);
@@ -43199,64 +43249,64 @@ Returncode tl5_compiler_M_SyntaxTreeConstant_parse(tl5_compiler_M_SyntaxTreeCons
     Ref_Manager* aux_String_6_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(489, self, self_Refman)
+    CHECK_REF(494, self, self_Refman)
     self->_base.access = tl5_compiler_M_Access_VAR;
-    CHECK_REF(490, self, self_Refman)
+    CHECK_REF(495, self, self_Refman)
     self->_base.constant = true;
-    CHECK_REF(491, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(491, self, self_Refman)
+    CHECK_REF(496, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(496, self, self_Refman)
     aux_Ref_Manager = self->_base.my_module_Refman;
     self->_base.my_module_Refman = tl5_compiler_M_glob->current_module_Refman;
     LUMI_inc_ref(self->_base.my_module_Refman);
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     self->_base.my_module = tl5_compiler_M_glob->current_module;
-    INIT_STRING_CONST(493, aux_String_0, " ");
+    INIT_STRING_CONST(498, aux_String_0, " ");
     LUMI_err = tl5_compiler_M_read_until(aux_String_0, aux_String_0_Refman, false, &(type_name), &(type_name_Refman), &(aux_Int_0));
-    CHECK(493)
-    INIT_STRING_CONST(494, aux_String_1, "Int");
-    LUMI_err = String_equal(type_name, type_name_Refman, aux_String_1, aux_String_1_Refman, &(aux_Bool_0));
-    CHECK(494)
-    if (! aux_Bool_0) {
-        INIT_STRING_CONST(496, aux_String_2, "Only \"Int\" typed constant supported, got");
-        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_2, aux_String_2_Refman, type_name, type_name_Refman);
-        CHECK(495)
-    }
-    INIT_STRING_CONST(498, aux_String_3, "Int");
-    LUMI_err = tl5_compiler_M_SyntaxTreeNode_expect_space(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_3, aux_String_3_Refman);
     CHECK(498)
-    INIT_STRING_CONST(499, aux_String_4, " ");
-    CHECK_REF(499, self, self_Refman)
-    LUMI_err = tl5_compiler_M_read_new(aux_String_4, aux_String_4_Refman, &(self->_base.name), &(self->_base.name_Refman));
+    INIT_STRING_CONST(499, aux_String_1, "Int");
+    LUMI_err = String_equal(type_name, type_name_Refman, aux_String_1, aux_String_1_Refman, &(aux_Bool_0));
     CHECK(499)
-    CHECK_REF(500, self, self_Refman)
-    LUMI_err = tl5_compiler_M_is_legal_name(self->_base.name, self->_base.name_Refman, tl5_compiler_M_NameGroup_CONSTANT, &(aux_Bool_1));
-    CHECK(500)
-    if (! aux_Bool_1) {
-        INIT_STRING_CONST(501, aux_String_5, "illegal constant name");
-        CHECK_REF(501, self, self_Refman)
-        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_5, aux_String_5_Refman, self->_base.name, self->_base.name_Refman);
-        CHECK(501)
+    if (! aux_Bool_0) {
+        INIT_STRING_CONST(501, aux_String_2, "Only \"Int\" typed constant supported, got");
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_2, aux_String_2_Refman, type_name, type_name_Refman);
+        CHECK(500)
     }
-    CHECK_REF(502, self, self_Refman)
-    if (! self->_base.is_native) {
-        CHECK_REF(503, self, self_Refman)
-        LUMI_err = tl5_compiler_M_SyntaxTreeNode_expect_space(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), self->_base.name, self->_base.name_Refman);
-        CHECK(503)
-        CHECK_REF(504, self, self_Refman)
-        INIT_STRING_CONST(504, aux_String_6, "");
-        LUMI_err = tl5_compiler_M_ExpressionValue_new(&(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic, aux_String_6, aux_String_6_Refman, &(self->_base._base), self_Refman, &(self_Dynamic->_base._base));
-        CHECK(504)
-    }
-    CHECK_REF(505, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    INIT_STRING_CONST(503, aux_String_3, "Int");
+    LUMI_err = tl5_compiler_M_SyntaxTreeNode_expect_space(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_3, aux_String_3_Refman);
+    CHECK(503)
+    INIT_STRING_CONST(504, aux_String_4, " ");
+    CHECK_REF(504, self, self_Refman)
+    LUMI_err = tl5_compiler_M_read_new(aux_String_4, aux_String_4_Refman, &(self->_base.name), &(self->_base.name_Refman));
+    CHECK(504)
     CHECK_REF(505, self, self_Refman)
-    LUMI_err = tl5_compiler_M_TypeData_new_type_instance(tl5_compiler_M_glob->type_int, tl5_compiler_M_glob->type_int_Refman, tl5_compiler_M_glob->type_int_Dynamic, &(self->_base.type_instance), &(self->_base.type_instance_Refman));
+    LUMI_err = tl5_compiler_M_is_legal_name(self->_base.name, self->_base.name_Refman, tl5_compiler_M_NameGroup_CONSTANT, &(aux_Bool_1));
     CHECK(505)
-    CHECK_REF(506, self, self_Refman)
-    CHECK_REF(506, self->_base.my_module, self->_base.my_module_Refman)
-    CHECK_REF(506, self, self_Refman)
+    if (! aux_Bool_1) {
+        INIT_STRING_CONST(506, aux_String_5, "illegal constant name");
+        CHECK_REF(506, self, self_Refman)
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_5, aux_String_5_Refman, self->_base.name, self->_base.name_Refman);
+        CHECK(506)
+    }
+    CHECK_REF(507, self, self_Refman)
+    if (! self->_base.is_native) {
+        CHECK_REF(508, self, self_Refman)
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_expect_space(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), self->_base.name, self->_base.name_Refman);
+        CHECK(508)
+        CHECK_REF(509, self, self_Refman)
+        INIT_STRING_CONST(509, aux_String_6, "");
+        LUMI_err = tl5_compiler_M_ExpressionValue_new(&(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic, aux_String_6, aux_String_6_Refman, &(self->_base._base), self_Refman, &(self_Dynamic->_base._base));
+        CHECK(509)
+    }
+    CHECK_REF(510, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(510, self, self_Refman)
+    LUMI_err = tl5_compiler_M_TypeData_new_type_instance(tl5_compiler_M_glob->type_int, tl5_compiler_M_glob->type_int_Refman, tl5_compiler_M_glob->type_int_Dynamic, &(self->_base.type_instance), &(self->_base.type_instance_Refman));
+    CHECK(510)
+    CHECK_REF(511, self, self_Refman)
+    CHECK_REF(511, self->_base.my_module, self->_base.my_module_Refman)
+    CHECK_REF(511, self, self_Refman)
     LUMI_err = tl5_compiler_M_NameMap_add(&(self->_base.my_module->variable_map), self->_base.my_module_Refman, self->_base.name, self->_base.name_Refman, &(self->_base), self_Refman, (void*)&(self_Dynamic->_base));
-    CHECK(506)
+    CHECK(511)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_6_Refman);
     LUMI_var_dec_ref(aux_String_5_Refman);
@@ -43294,37 +43344,37 @@ Returncode tl5_compiler_M_SyntaxTreeConstant_analyze(tl5_compiler_M_SyntaxTreeCo
     Ref_Manager* aux_String_0_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(512, self, self_Refman)
+    CHECK_REF(517, self, self_Refman)
     if (self->analyzed) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(514, self, self_Refman)
+    CHECK_REF(519, self, self_Refman)
     self->analyzed = true;
-    CHECK_REF(515, self, self_Refman)
-    CHECK_REF(515, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(520, self, self_Refman)
+    CHECK_REF(520, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     aux_Ref_Manager = tl5_compiler_M_glob->current_module_Refman;
     tl5_compiler_M_glob->current_module_Refman = self->_base.my_module_Refman;
     LUMI_inc_ref(tl5_compiler_M_glob->current_module_Refman);
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     tl5_compiler_M_glob->current_module = self->_base.my_module;
-    CHECK_REF(516, self, self_Refman)
-    CHECK_REF(516, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(521, self, self_Refman)
+    CHECK_REF(521, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     LUMI_err = tl5_compiler_M_SyntaxTreeNode_analyze_expression(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), &(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic, tl5_compiler_M_glob->type_int, tl5_compiler_M_glob->type_int_Refman, tl5_compiler_M_glob->type_int_Dynamic);
-    CHECK(516)
-    CHECK_REF(517, self, self_Refman)
+    CHECK(521)
+    CHECK_REF(522, self, self_Refman)
     LUMI_err = tl5_compiler_M_ExpressionValue_check_no_error(&(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic);
-    CHECK(517)
-    CHECK_REF(518, self, self_Refman)
-    CHECK_REF(518, self, self_Refman)
+    CHECK(522)
+    CHECK_REF(523, self, self_Refman)
+    CHECK_REF(523, self, self_Refman)
     LUMI_err = tl5_compiler_M_ExpressionValue_get_constant_value(&(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic, &(self->int_value), &(aux_Bool_0));
-    CHECK(518)
+    CHECK(523)
     if (! aux_Bool_0) {
-        INIT_STRING_CONST(519, aux_String_0, "value is not constant");
+        INIT_STRING_CONST(524, aux_String_0, "value is not constant");
         LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error_msg(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_0, aux_String_0_Refman);
-        CHECK(519)
+        CHECK(524)
     }
-    CHECK_REF(520, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(525, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     aux_Ref_Manager = tl5_compiler_M_glob->current_module_Refman;
     tl5_compiler_M_glob->current_module_Refman = NULL;
     LUMI_inc_ref(tl5_compiler_M_glob->current_module_Refman);
@@ -43348,26 +43398,26 @@ Returncode tl5_compiler_M_SyntaxTreeConstant_order_constants(tl5_compiler_M_Synt
     Ref_Manager* aux_String_0_Refman = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(ordered_list_Refman);
-    CHECK_REF(523, self, self_Refman)
+    CHECK_REF(528, self, self_Refman)
     if (self->is_ordered) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(525, self, self_Refman)
-    if (self->ordering) {
-        INIT_STRING_CONST(527, aux_String_0, "recursive dependency in constant");
-        CHECK_REF(527, self, self_Refman)
-        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_0, aux_String_0_Refman, self->_base.name, self->_base.name_Refman);
-        CHECK(526)
-    }
-    CHECK_REF(528, self, self_Refman)
-    self->ordering = true;
-    CHECK_REF(529, self, self_Refman)
-    LUMI_err = tl5_compiler_M_ExpressionValue_order_constants(&(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic, ordered_list, ordered_list_Refman);
-    CHECK(529)
     CHECK_REF(530, self, self_Refman)
+    if (self->ordering) {
+        INIT_STRING_CONST(532, aux_String_0, "recursive dependency in constant");
+        CHECK_REF(532, self, self_Refman)
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_0, aux_String_0_Refman, self->_base.name, self->_base.name_Refman);
+        CHECK(531)
+    }
+    CHECK_REF(533, self, self_Refman)
+    self->ordering = true;
+    CHECK_REF(534, self, self_Refman)
+    LUMI_err = tl5_compiler_M_ExpressionValue_order_constants(&(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic, ordered_list, ordered_list_Refman);
+    CHECK(534)
+    CHECK_REF(535, self, self_Refman)
     LUMI_err = tl5_compiler_M_NameMap_add(ordered_list, ordered_list_Refman, self->_base.name, self->_base.name_Refman, self, self_Refman, (void*)self_Dynamic);
-    CHECK(530)
-    CHECK_REF(531, self, self_Refman)
+    CHECK(535)
+    CHECK_REF(536, self, self_Refman)
     self->is_ordered = true;
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_0_Refman);
@@ -43383,10 +43433,10 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_SyntaxTreeConstant_get_constant_value(tl5_compiler_M_SyntaxTreeConstant* self, Ref_Manager* self_Refman, tl5_compiler_M_SyntaxTreeConstant_Dynamic* self_Dynamic, Int* value, Bool* has_value) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
-    if (self_Dynamic == NULL) RAISE(534, empty_object)
+    if (self_Dynamic == NULL) RAISE(539, empty_object)
     LUMI_err = self_Dynamic->_base._base._base.analyze(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base));
-    CHECK(534)
-    CHECK_REF(535, self, self_Refman)
+    CHECK(539)
+    CHECK_REF(540, self, self_Refman)
     *value = self->int_value;
     *has_value = true;
 LUMI_cleanup:
@@ -43410,26 +43460,26 @@ Returncode tl5_compiler_M_SyntaxTreeConstant_write(tl5_compiler_M_SyntaxTreeCons
     String* aux_String_2 = NULL;
     Ref_Manager* aux_String_2_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(539, self, self_Refman)
+    CHECK_REF(544, self, self_Refman)
     if (! self->is_ordered) {
         goto LUMI_cleanup;
     }
-    INIT_STRING_CONST(542, aux_String_0, "\nenum { ");
+    INIT_STRING_CONST(547, aux_String_0, "\nenum { ");
     LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(542)
-    if (self_Dynamic == NULL) RAISE(543, empty_object)
+    CHECK(547)
+    if (self_Dynamic == NULL) RAISE(548, empty_object)
     LUMI_err = self_Dynamic->_base.write_cname(&(self->_base), self_Refman, &(self_Dynamic->_base));
-    CHECK(543)
-    INIT_STRING_CONST(544, aux_String_1, " = ");
+    CHECK(548)
+    INIT_STRING_CONST(549, aux_String_1, " = ");
     LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-    CHECK(544)
-    CHECK_REF(545, self, self_Refman)
+    CHECK(549)
+    CHECK_REF(550, self, self_Refman)
     LUMI_err = tl5_compiler_M_write_int(self->int_value);
-    CHECK(545)
-    INIT_STRING_CONST(546, aux_String_2, " };\n");
+    CHECK(550)
+    INIT_STRING_CONST(551, aux_String_2, " };\n");
     LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-    CHECK(546)
-    CHECK_REF(547, self, self_Refman)
+    CHECK(551)
+    CHECK_REF(552, self, self_Refman)
     self->is_ordered = false;
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_2_Refman);
@@ -47308,7 +47358,7 @@ Returncode tl5_compiler_M_VariableCreate_new(tl5_compiler_M_VariableCreate* self
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(variable_Refman);
-    CHECK_REF(400, self, self_Refman)
+    CHECK_REF(405, self, self_Refman)
     aux_Ref_Manager = self->variable_Refman;
     self->variable_Refman = variable_Refman;
     self->variable_Dynamic = variable_Dynamic;
@@ -47316,9 +47366,9 @@ Returncode tl5_compiler_M_VariableCreate_new(tl5_compiler_M_VariableCreate* self
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     self->variable = variable;
-    CHECK_REF(401, variable, variable_Refman)
+    CHECK_REF(406, variable, variable_Refman)
     LUMI_err = tl5_compiler_M_SyntaxTreeCode_new(&(self->_base), self_Refman, &(self_Dynamic->_base), variable->_base.parent, variable->_base.parent_Refman, variable->_base.parent_Dynamic);
-    CHECK(401)
+    CHECK(406)
 LUMI_cleanup:
     LUMI_dec_ref(variable_Refman);
     LUMI_dec_ref(self_Refman);
@@ -47332,8 +47382,8 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_VariableCreate_analyze(tl5_compiler_M_VariableCreate* self, Ref_Manager* self_Refman, tl5_compiler_M_VariableCreate_Dynamic* self_Dynamic) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(404, self, self_Refman)
-    CHECK_REF(404, self->variable, self->variable_Refman)
+    CHECK_REF(409, self, self_Refman)
+    CHECK_REF(409, self->variable, self->variable_Refman)
     self->variable->not_declared_yet = false;
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
@@ -47351,18 +47401,18 @@ Returncode tl5_compiler_M_VariableCreate_check_memory(tl5_compiler_M_VariableCre
     Ref_Manager* reference_path_Refman = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(refs_Refman);
-    CHECK_REF(407, self, self_Refman)
-    INIT_VAR(407, reference_path)
+    CHECK_REF(412, self, self_Refman)
+    INIT_VAR(412, reference_path)
     LUMI_err = tl5_compiler_M_ReferencePath_new(reference_path, reference_path_Refman, self->variable, self->variable_Refman, self->variable_Dynamic);
-    CHECK(407)
-    CHECK_REF(409, self, self_Refman)
-    CHECK_REF(409, self->variable, self->variable_Refman)
-    CHECK_REF(409, self->variable->type_instance, self->variable->type_instance_Refman)
-    CHECK_REF(408, self, self_Refman)
-    CHECK_REF(408, self->variable, self->variable_Refman)
+    CHECK(412)
+    CHECK_REF(414, self, self_Refman)
+    CHECK_REF(414, self->variable, self->variable_Refman)
+    CHECK_REF(414, self->variable->type_instance, self->variable->type_instance_Refman)
+    CHECK_REF(413, self, self_Refman)
+    CHECK_REF(413, self->variable, self->variable_Refman)
     if (self->variable->is_initialized || self->variable->type_instance->conditional) {
         LUMI_err = tl5_compiler_M_ReferenceMemoryList_clear_invalid_reference(refs, refs_Refman, reference_path, reference_path_Refman);
-        CHECK(410)
+        CHECK(415)
     }
 LUMI_cleanup:
     LUMI_var_dec_ref(reference_path_Refman);
@@ -47400,18 +47450,18 @@ Returncode tl5_compiler_M_VariableInit_parse_new(tl5_compiler_M_VariableInit* se
     tl5_compiler_M_VariableInit_Dynamic* new_node_Dynamic = &tl5_compiler_M_VariableInit_dynamic;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(variable_Refman);
-    INIT_NEW(420, new_node, LUMI_alloc(sizeof(tl5_compiler_M_VariableInit)));
+    INIT_NEW(425, new_node, LUMI_alloc(sizeof(tl5_compiler_M_VariableInit)));
     LUMI_err = tl5_compiler_M_VariableCreate_new(&(new_node->_base), new_node_Refman, &(new_node_Dynamic->_base), variable, variable_Refman, variable_Dynamic);
-    CHECK(420)
+    CHECK(425)
     LUMI_err = tl5_compiler_M_VariableInit_parse(new_node, new_node_Refman, new_node_Dynamic);
-    CHECK(421)
-    CHECK_REF(422, variable, variable_Refman)
-    CHECK_REF(422, variable->_base.parent, variable->_base.parent_Refman)
+    CHECK(426)
+    CHECK_REF(427, variable, variable_Refman)
+    CHECK_REF(427, variable->_base.parent, variable->_base.parent_Refman)
     LUMI_err = tl5_compiler_M_List_add(&(variable->_base.parent->code_nodes), variable->_base.parent_Refman, &(new_node->_base._base), new_node_Refman, (void*)&(new_node_Dynamic->_base._base));
     new_node = NULL;
     new_node_Refman = NULL;
     new_node_Dynamic = NULL;
-    CHECK(422)
+    CHECK(427)
 LUMI_cleanup:
     if (new_node_Dynamic != NULL) new_node_Dynamic->_base._base._base._del(new_node);
     LUMI_owner_dec_ref(new_node_Refman);
@@ -47449,16 +47499,16 @@ Returncode tl5_compiler_M_VariableInit_parse(tl5_compiler_M_VariableInit* self, 
     Ref_Manager* aux_ReferencePath_1_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    INIT_NEW(425, aux_InitExpression_0, LUMI_alloc(sizeof(tl5_compiler_M_InitExpression)));
+    INIT_NEW(430, aux_InitExpression_0, LUMI_alloc(sizeof(tl5_compiler_M_InitExpression)));
     LUMI_err = tl5_compiler_M_InitExpression_new(aux_InitExpression_0, aux_InitExpression_0_Refman, aux_InitExpression_0_Dynamic, &(self->_base._base), self_Refman, &(self_Dynamic->_base._base));
-    CHECK(425)
+    CHECK(430)
     aux_InitExpression_1 = aux_InitExpression_0;
     aux_InitExpression_1_Refman = aux_InitExpression_0_Refman;
     aux_InitExpression_1_Dynamic = aux_InitExpression_0_Dynamic;
     aux_InitExpression_0 = NULL;
     aux_InitExpression_0_Refman = NULL;
     aux_InitExpression_0_Dynamic = NULL;
-    CHECK_REF(425, self, self_Refman)
+    CHECK_REF(430, self, self_Refman)
     if (self->expression_init_Dynamic != NULL) self->expression_init_Dynamic->_base._base._base._del(self->expression_init);
     LUMI_owner_dec_ref(self->expression_init_Refman);
     self->expression_init_Refman = aux_InitExpression_1_Refman;
@@ -47468,38 +47518,38 @@ Returncode tl5_compiler_M_VariableInit_parse(tl5_compiler_M_VariableInit* self, 
     aux_InitExpression_1_Refman = NULL;
     aux_InitExpression_1_Dynamic = NULL;
     LUMI_err = tl5_compiler_M_VariableInit_check_error_mark(self, self_Refman, self_Dynamic);
-    CHECK(426)
-    CHECK_REF(427, self, self_Refman)
-    CHECK_REF(428, self, self_Refman)
-    CHECK_REF(428, self->_base.variable, self->_base.variable_Refman)
+    CHECK(431)
+    CHECK_REF(432, self, self_Refman)
+    CHECK_REF(433, self, self_Refman)
+    CHECK_REF(433, self->_base.variable, self->_base.variable_Refman)
     LUMI_err = tl5_compiler_M_TypeInstance_copy_new(self->_base.variable->type_instance, self->_base.variable->type_instance_Refman, &(aux_TypeInstance_0), &(aux_TypeInstance_0_Refman));
-    CHECK(427)
+    CHECK(432)
     LUMI_err = tl5_compiler_M_InitExpression_parse(self->expression_init, self->expression_init_Refman, self->expression_init_Dynamic, aux_TypeInstance_0, aux_TypeInstance_0_Refman, NULL, NULL, NULL);
     aux_TypeInstance_0 = NULL;
     aux_TypeInstance_0_Refman = NULL;
-    CHECK(427)
+    CHECK(432)
     LUMI_err = tl5_compiler_M_VariableInit_check_error_mark(self, self_Refman, self_Dynamic);
-    CHECK(429)
-    CHECK_REF(430, self, self_Refman)
-    CHECK_REF(430, self->expression_init, self->expression_init_Refman)
+    CHECK(434)
+    CHECK_REF(435, self, self_Refman)
+    CHECK_REF(435, self->expression_init, self->expression_init_Refman)
     self->expression_init->_base._base.is_statement = true;
-    CHECK_REF(432, self, self_Refman)
-    CHECK_REF(432, self->_base.variable, self->_base.variable_Refman)
+    CHECK_REF(437, self, self_Refman)
+    CHECK_REF(437, self->_base.variable, self->_base.variable_Refman)
     LUMI_err = tl5_compiler_M_string_new_copy(self->_base.variable->name, self->_base.variable->name_Refman, &(aux_String_0), &(aux_String_0_Refman));
-    CHECK(431)
-    INIT_NEW(431, aux_VariableExpression_0, LUMI_alloc(sizeof(tl5_compiler_M_VariableExpression)));
+    CHECK(436)
+    INIT_NEW(436, aux_VariableExpression_0, LUMI_alloc(sizeof(tl5_compiler_M_VariableExpression)));
     LUMI_err = tl5_compiler_M_VariableExpression_new(aux_VariableExpression_0, aux_VariableExpression_0_Refman, aux_VariableExpression_0_Dynamic, &(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_0, aux_String_0_Refman);
     aux_String_0 = NULL;
     aux_String_0_Refman = NULL;
-    CHECK(431)
+    CHECK(436)
     aux_VariableExpression_1 = aux_VariableExpression_0;
     aux_VariableExpression_1_Refman = aux_VariableExpression_0_Refman;
     aux_VariableExpression_1_Dynamic = aux_VariableExpression_0_Dynamic;
     aux_VariableExpression_0 = NULL;
     aux_VariableExpression_0_Refman = NULL;
     aux_VariableExpression_0_Dynamic = NULL;
-    CHECK_REF(431, self, self_Refman)
-    CHECK_REF(431, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(436, self, self_Refman)
+    CHECK_REF(436, self->expression_init, self->expression_init_Refman)
     if (self->expression_init->aux_variable_Dynamic != NULL) self->expression_init->aux_variable_Dynamic->_base._base._del(self->expression_init->aux_variable);
     LUMI_owner_dec_ref(self->expression_init->aux_variable_Refman);
     self->expression_init->aux_variable_Refman = aux_VariableExpression_1_Refman;
@@ -47508,10 +47558,10 @@ Returncode tl5_compiler_M_VariableInit_parse(tl5_compiler_M_VariableInit* self, 
     aux_VariableExpression_1 = NULL;
     aux_VariableExpression_1_Refman = NULL;
     aux_VariableExpression_1_Dynamic = NULL;
-    CHECK_REF(433, self, self_Refman)
-    CHECK_REF(433, self, self_Refman)
-    CHECK_REF(433, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(433, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
+    CHECK_REF(438, self, self_Refman)
+    CHECK_REF(438, self, self_Refman)
+    CHECK_REF(438, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(438, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
     aux_Ref_Manager = self->expression_init->aux_variable->variable_Refman;
     self->expression_init->aux_variable->variable_Refman = self->_base.variable_Refman;
     self->expression_init->aux_variable->variable_Dynamic = self->_base.variable_Dynamic;
@@ -47519,41 +47569,41 @@ Returncode tl5_compiler_M_VariableInit_parse(tl5_compiler_M_VariableInit* self, 
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     self->expression_init->aux_variable->variable = self->_base.variable;
-    CHECK_REF(434, self, self_Refman)
-    CHECK_REF(434, self->_base.variable, self->_base.variable_Refman)
-    CHECK_REF(435, self, self_Refman)
-    CHECK_REF(435, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(435, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
-    LUMI_err = tl5_compiler_M_TypeInstance_copy_new(self->_base.variable->type_instance, self->_base.variable->type_instance_Refman, &(self->expression_init->aux_variable->_base.result_type), &(self->expression_init->aux_variable->_base.result_type_Refman));
-    CHECK(434)
-    CHECK_REF(436, self, self_Refman)
-    CHECK_REF(436, self->_base.variable, self->_base.variable_Refman)
-    CHECK_REF(436, self, self_Refman)
-    CHECK_REF(436, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(436, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
-    self->expression_init->aux_variable->_base.access = self->_base.variable->access;
-    CHECK_REF(438, self, self_Refman)
-    CHECK_REF(438, self->_base.variable, self->_base.variable_Refman)
-    LUMI_err = tl5_compiler_M_access_is_only_var(self->_base.variable->access, &(aux_Bool_0));
-    CHECK(437)
-    CHECK_REF(437, self, self_Refman)
-    CHECK_REF(437, self->_base.variable, self->_base.variable_Refman)
-    CHECK_REF(437, self, self_Refman)
-    CHECK_REF(437, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(437, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
-    self->expression_init->aux_variable->_base.is_var = self->_base.variable->is_create && aux_Bool_0;
+    CHECK_REF(439, self, self_Refman)
+    CHECK_REF(439, self->_base.variable, self->_base.variable_Refman)
     CHECK_REF(440, self, self_Refman)
-    INIT_NEW(440, aux_ReferencePath_0, LUMI_alloc(sizeof(tl5_compiler_M_ReferencePath)));
-    LUMI_err = tl5_compiler_M_ReferencePath_new(aux_ReferencePath_0, aux_ReferencePath_0_Refman, self->_base.variable, self->_base.variable_Refman, self->_base.variable_Dynamic);
+    CHECK_REF(440, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(440, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
+    LUMI_err = tl5_compiler_M_TypeInstance_copy_new(self->_base.variable->type_instance, self->_base.variable->type_instance_Refman, &(self->expression_init->aux_variable->_base.result_type), &(self->expression_init->aux_variable->_base.result_type_Refman));
     CHECK(439)
+    CHECK_REF(441, self, self_Refman)
+    CHECK_REF(441, self->_base.variable, self->_base.variable_Refman)
+    CHECK_REF(441, self, self_Refman)
+    CHECK_REF(441, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(441, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
+    self->expression_init->aux_variable->_base.access = self->_base.variable->access;
+    CHECK_REF(443, self, self_Refman)
+    CHECK_REF(443, self->_base.variable, self->_base.variable_Refman)
+    LUMI_err = tl5_compiler_M_access_is_only_var(self->_base.variable->access, &(aux_Bool_0));
+    CHECK(442)
+    CHECK_REF(442, self, self_Refman)
+    CHECK_REF(442, self->_base.variable, self->_base.variable_Refman)
+    CHECK_REF(442, self, self_Refman)
+    CHECK_REF(442, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(442, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
+    self->expression_init->aux_variable->_base.is_var = self->_base.variable->is_create && aux_Bool_0;
+    CHECK_REF(445, self, self_Refman)
+    INIT_NEW(445, aux_ReferencePath_0, LUMI_alloc(sizeof(tl5_compiler_M_ReferencePath)));
+    LUMI_err = tl5_compiler_M_ReferencePath_new(aux_ReferencePath_0, aux_ReferencePath_0_Refman, self->_base.variable, self->_base.variable_Refman, self->_base.variable_Dynamic);
+    CHECK(444)
     aux_ReferencePath_1 = aux_ReferencePath_0;
     aux_ReferencePath_1_Refman = aux_ReferencePath_0_Refman;
     aux_ReferencePath_0 = NULL;
     aux_ReferencePath_0_Refman = NULL;
-    CHECK_REF(439, self, self_Refman)
-    CHECK_REF(439, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(439, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
-    CHECK_REF(439, self->expression_init->aux_variable->_base.result_type, self->expression_init->aux_variable->_base.result_type_Refman)
+    CHECK_REF(444, self, self_Refman)
+    CHECK_REF(444, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(444, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
+    CHECK_REF(444, self->expression_init->aux_variable->_base.result_type, self->expression_init->aux_variable->_base.result_type_Refman)
     tl5_compiler_M_ReferencePath_Del(self->expression_init->aux_variable->_base.result_type->reference_path);
     LUMI_owner_dec_ref(self->expression_init->aux_variable->_base.result_type->reference_path_Refman);
     self->expression_init->aux_variable->_base.result_type->reference_path_Refman = aux_ReferencePath_1_Refman;
@@ -47588,16 +47638,16 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_VariableInit_check_error_mark(tl5_compiler_M_VariableInit* self, Ref_Manager* self_Refman, tl5_compiler_M_VariableInit_Dynamic* self_Dynamic) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(443, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(448, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     if (tl5_compiler_M_glob->last_char == '!') {
-        CHECK_REF(444, self, self_Refman)
-        CHECK_REF(444, self->expression_init, self->expression_init_Refman)
+        CHECK_REF(449, self, self_Refman)
+        CHECK_REF(449, self->expression_init, self->expression_init_Refman)
         self->expression_init->_base._base.error_propagated = true;
-        CHECK_REF(445, self, self_Refman)
-        CHECK_REF(445, self->expression_init, self->expression_init_Refman)
+        CHECK_REF(450, self, self_Refman)
+        CHECK_REF(450, self->expression_init, self->expression_init_Refman)
         self->expression_init->_base._base.error_expected = true;
         LUMI_err = tl5_compiler_M_read_c();
-        CHECK(446)
+        CHECK(451)
     }
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
@@ -47612,12 +47662,12 @@ Returncode tl5_compiler_M_VariableInit_analyze(tl5_compiler_M_VariableInit* self
     Returncode LUMI_err = OK;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(449, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(449, self, self_Refman)
+    CHECK_REF(454, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(454, self, self_Refman)
     if ((void*)self->_base._base.parent == &(tl5_compiler_M_glob->root.global_init)) {
-        CHECK_REF(450, self, self_Refman)
-        CHECK_REF(450, self->_base.variable, self->_base.variable_Refman)
-        CHECK_REF(450, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(455, self, self_Refman)
+        CHECK_REF(455, self->_base.variable, self->_base.variable_Refman)
+        CHECK_REF(455, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
         aux_Ref_Manager = tl5_compiler_M_glob->current_module_Refman;
         tl5_compiler_M_glob->current_module_Refman = self->_base.variable->my_module_Refman;
         LUMI_inc_ref(tl5_compiler_M_glob->current_module_Refman);
@@ -47625,14 +47675,14 @@ Returncode tl5_compiler_M_VariableInit_analyze(tl5_compiler_M_VariableInit* self
         aux_Ref_Manager = NULL;
         tl5_compiler_M_glob->current_module = self->_base.variable->my_module;
     }
-    CHECK_REF(451, self, self_Refman)
-    if (self->expression_init_Dynamic == NULL) RAISE(451, empty_object)
+    CHECK_REF(456, self, self_Refman)
+    if (self->expression_init_Dynamic == NULL) RAISE(456, empty_object)
     LUMI_err = self->expression_init_Dynamic->_base._base._base.analyze(&(self->expression_init->_base._base._base), self->expression_init_Refman, &(self->expression_init_Dynamic->_base._base._base));
-    CHECK(451)
-    CHECK_REF(452, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(452, self, self_Refman)
+    CHECK(456)
+    CHECK_REF(457, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(457, self, self_Refman)
     if ((void*)self->_base._base.parent == &(tl5_compiler_M_glob->root.global_init)) {
-        CHECK_REF(453, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(458, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
         aux_Ref_Manager = tl5_compiler_M_glob->current_module_Refman;
         tl5_compiler_M_glob->current_module_Refman = NULL;
         LUMI_inc_ref(tl5_compiler_M_glob->current_module_Refman);
@@ -47640,19 +47690,19 @@ Returncode tl5_compiler_M_VariableInit_analyze(tl5_compiler_M_VariableInit* self
         aux_Ref_Manager = NULL;
         tl5_compiler_M_glob->current_module = NULL;
     }
-    CHECK_REF(455, self, self_Refman)
-    CHECK_REF(455, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(454, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(454, self, self_Refman)
-    CHECK_REF(454, self->_base.variable, self->_base.variable_Refman)
-    CHECK_REF(454, self->_base.variable->type_instance, self->_base.variable->type_instance_Refman)
+    CHECK_REF(460, self, self_Refman)
+    CHECK_REF(460, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(459, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(459, self, self_Refman)
+    CHECK_REF(459, self->_base.variable, self->_base.variable_Refman)
+    CHECK_REF(459, self->_base.variable->type_instance, self->_base.variable->type_instance_Refman)
     if (((void*)self->_base.variable->type_instance->type_data == tl5_compiler_M_glob->type_func) && (! (self->expression_init->arguments.parameters.first != NULL && self->expression_init->arguments.parameters.first_Refman->value != NULL))) {
-        CHECK_REF(456, self, self_Refman)
-        CHECK_REF(456, self->_base.variable, self->_base.variable_Refman)
+        CHECK_REF(461, self, self_Refman)
+        CHECK_REF(461, self->_base.variable, self->_base.variable_Refman)
         self->_base.variable->is_initialized = false;
     }
     LUMI_err = tl5_compiler_M_VariableCreate_analyze(&(self->_base), self_Refman, &(self_Dynamic->_base));
-    CHECK(457)
+    CHECK(462)
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
     return LUMI_err;
@@ -47666,15 +47716,15 @@ Returncode tl5_compiler_M_VariableInit_check_memory(tl5_compiler_M_VariableInit*
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(refs_Refman);
-    CHECK_REF(460, self, self_Refman)
-    if (self->expression_init_Dynamic == NULL) RAISE(460, empty_object)
+    CHECK_REF(465, self, self_Refman)
+    if (self->expression_init_Dynamic == NULL) RAISE(465, empty_object)
     LUMI_err = self->expression_init_Dynamic->_base._base._base.check_memory(&(self->expression_init->_base._base._base), self->expression_init_Refman, &(self->expression_init_Dynamic->_base._base._base), refs, refs_Refman);
-    CHECK(460)
-    CHECK_REF(461, self, self_Refman)
+    CHECK(465)
+    CHECK_REF(466, self, self_Refman)
     LUMI_err = tl5_compiler_M_ReferenceMemoryList_add(refs, refs_Refman, self->_base.variable, self->_base.variable_Refman, self->_base.variable_Dynamic);
-    CHECK(461)
+    CHECK(466)
     LUMI_err = tl5_compiler_M_VariableCreate_check_memory(&(self->_base), self_Refman, &(self_Dynamic->_base), refs, refs_Refman);
-    CHECK(462)
+    CHECK(467)
 LUMI_cleanup:
     LUMI_dec_ref(refs_Refman);
     LUMI_dec_ref(self_Refman);
@@ -47697,39 +47747,39 @@ Returncode tl5_compiler_M_VariableInit_write(tl5_compiler_M_VariableInit* self, 
     String* aux_String_2 = NULL;
     Ref_Manager* aux_String_2_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(466, self, self_Refman)
-    CHECK_REF(466, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(465, self, self_Refman)
-    CHECK_REF(465, self->_base.variable, self->_base.variable_Refman)
-    CHECK_REF(465, self->_base.variable->type_instance, self->_base.variable->type_instance_Refman)
-    CHECK_REF(465, self->_base.variable->type_instance->type_data, self->_base.variable->type_instance->type_data_Refman)
+    CHECK_REF(471, self, self_Refman)
+    CHECK_REF(471, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(470, self, self_Refman)
+    CHECK_REF(470, self->_base.variable, self->_base.variable_Refman)
+    CHECK_REF(470, self->_base.variable->type_instance, self->_base.variable->type_instance_Refman)
+    CHECK_REF(470, self->_base.variable->type_instance->type_data, self->_base.variable->type_instance->type_data_Refman)
     if (self->_base.variable->type_instance->type_data->is_primitive && (! (self->expression_init->arguments.parameters.first != NULL && self->expression_init->arguments.parameters.first_Refman->value != NULL))) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(468, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(468, self, self_Refman)
-    if ((void*)self->_base._base.parent == &(tl5_compiler_M_glob->root.global_init)) {
-        INIT_STRING_CONST(469, aux_String_0, "#define LUMI_FILE_NAME ");
-        LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-        CHECK(469)
-        CHECK_REF(470, self, self_Refman)
-        CHECK_REF(470, self->_base.variable, self->_base.variable_Refman)
-        LUMI_err = tl5_compiler_M_write_string_literal(self->_base.variable->_base._base.input_file_name, self->_base.variable->_base._base.input_file_name_Refman);
-        CHECK(470)
-        INIT_STRING_CONST(471, aux_String_1, "\n");
-        LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-        CHECK(471)
-    }
-    CHECK_REF(472, self, self_Refman)
-    if (self->expression_init_Dynamic == NULL) RAISE(472, empty_object)
-    LUMI_err = self->expression_init_Dynamic->_base._base._base.write(&(self->expression_init->_base._base._base), self->expression_init_Refman, &(self->expression_init_Dynamic->_base._base._base));
-    CHECK(472)
     CHECK_REF(473, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     CHECK_REF(473, self, self_Refman)
     if ((void*)self->_base._base.parent == &(tl5_compiler_M_glob->root.global_init)) {
-        INIT_STRING_CONST(474, aux_String_2, "#undef LUMI_FILE_NAME\n");
-        LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
+        INIT_STRING_CONST(474, aux_String_0, "#define LUMI_FILE_NAME ");
+        LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
         CHECK(474)
+        CHECK_REF(475, self, self_Refman)
+        CHECK_REF(475, self->_base.variable, self->_base.variable_Refman)
+        LUMI_err = tl5_compiler_M_write_string_literal(self->_base.variable->_base._base.input_file_name, self->_base.variable->_base._base.input_file_name_Refman);
+        CHECK(475)
+        INIT_STRING_CONST(476, aux_String_1, "\n");
+        LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
+        CHECK(476)
+    }
+    CHECK_REF(477, self, self_Refman)
+    if (self->expression_init_Dynamic == NULL) RAISE(477, empty_object)
+    LUMI_err = self->expression_init_Dynamic->_base._base._base.write(&(self->expression_init->_base._base._base), self->expression_init_Refman, &(self->expression_init_Dynamic->_base._base._base));
+    CHECK(477)
+    CHECK_REF(478, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(478, self, self_Refman)
+    if ((void*)self->_base._base.parent == &(tl5_compiler_M_glob->root.global_init)) {
+        INIT_STRING_CONST(479, aux_String_2, "#undef LUMI_FILE_NAME\n");
+        LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
+        CHECK(479)
     }
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_2_Refman);

--- a/TL5/tl5-compiler.c
+++ b/TL5/tl5-compiler.c
@@ -27007,8 +27007,8 @@ Returncode tl5_compiler_M_GlobalInit_new(tl5_compiler_M_GlobalInit* self, Ref_Ma
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
     LUMI_err = tl5_compiler_M_SyntaxTreeFunction_new(&(self->_base), self_Refman, &(self_Dynamic->_base));
-    CHECK(450)
-    CHECK_REF(451, self, self_Refman)
+    CHECK(455)
+    CHECK_REF(456, self, self_Refman)
     self->_base._base._base.indentation_spaces = tl5_compiler_M_INDENTATION_SPACES;
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
@@ -27028,24 +27028,24 @@ Returncode tl5_compiler_M_GlobalInit_write(tl5_compiler_M_GlobalInit* self, Ref_
     String* aux_String_1 = NULL;
     Ref_Manager* aux_String_1_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(454, self, self_Refman)
+    CHECK_REF(459, self, self_Refman)
     if (! (self->_base._base.code_nodes.first != NULL && self->_base._base.code_nodes.first_Refman->value != NULL)) {
         goto LUMI_cleanup;
     }
     LUMI_err = tl5_compiler_M_SyntaxTreeFunction_write_setup(&(self->_base), self_Refman, &(self_Dynamic->_base));
-    CHECK(456)
-    CHECK_REF(457, self, self_Refman)
-    LUMI_err = tl5_compiler_M_SyntaxTreeNode_write_children(&(self->_base._base._base._base), self_Refman, &(self_Dynamic->_base._base._base._base), &(self->_base._base._base.variables), self_Refman);
-    CHECK(457)
-    INIT_STRING_CONST(459, aux_String_0, "#define LUMI_FUNC_NAME \"global variable initialization\"\n");
-    LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(458)
-    if (self_Dynamic == NULL) RAISE(460, empty_object)
-    LUMI_err = self_Dynamic->_base._base.write_block_body(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base));
-    CHECK(460)
-    INIT_STRING_CONST(461, aux_String_1, "#undef LUMI_FUNC_NAME\n");
-    LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
     CHECK(461)
+    CHECK_REF(462, self, self_Refman)
+    LUMI_err = tl5_compiler_M_SyntaxTreeNode_write_children(&(self->_base._base._base._base), self_Refman, &(self_Dynamic->_base._base._base._base), &(self->_base._base._base.variables), self_Refman);
+    CHECK(462)
+    INIT_STRING_CONST(464, aux_String_0, "#define LUMI_FUNC_NAME \"global variable initialization\"\n");
+    LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
+    CHECK(463)
+    if (self_Dynamic == NULL) RAISE(465, empty_object)
+    LUMI_err = self_Dynamic->_base._base.write_block_body(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base));
+    CHECK(465)
+    INIT_STRING_CONST(466, aux_String_1, "#undef LUMI_FUNC_NAME\n");
+    LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
+    CHECK(466)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_1_Refman);
     LUMI_var_dec_ref(aux_String_0_Refman);
@@ -27547,7 +27547,7 @@ Returncode tl5_compiler_M_SyntaxTreeRoot_parse_child(tl5_compiler_M_SyntaxTreeRo
                     }
                     else {
                         INIT_STRING_CONST(130, aux_String_4, "main");
-                        LUMI_err = tl5_compiler_M_SyntaxTreeBranch_equal_and_new_line(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), keyword, keyword_Refman, aux_String_4, aux_String_4_Refman, &(aux_Bool_5));
+                        LUMI_err = String_equal(keyword, keyword_Refman, aux_String_4, aux_String_4_Refman, &(aux_Bool_5));
                         CHECK(130)
                         if (aux_Bool_5) {
                             CHECK_REF(131, self, self_Refman)
@@ -41899,13 +41899,16 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_analyze(tl5_compiler_M_SyntaxTreeVa
     String aux_String_3_Var = {0};
     String* aux_String_3 = NULL;
     Ref_Manager* aux_String_3_Refman = NULL;
-    Bool aux_Bool_2 = 0;
     String aux_String_4_Var = {0};
     String* aux_String_4 = NULL;
     Ref_Manager* aux_String_4_Refman = NULL;
+    Bool aux_Bool_2 = 0;
     String aux_String_5_Var = {0};
     String* aux_String_5 = NULL;
     Ref_Manager* aux_String_5_Refman = NULL;
+    String aux_String_6_Var = {0};
+    String* aux_String_6 = NULL;
+    Ref_Manager* aux_String_6_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
     CHECK_REF(122, self, self_Refman)
@@ -41969,59 +41972,72 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_analyze(tl5_compiler_M_SyntaxTreeVa
         LUMI_err = tl5_compiler_M_TypeInstance_check_sequence(self->type_instance, self->type_instance_Refman, &(self->_base._base), self_Refman, &(self_Dynamic->_base._base));
         CHECK(141)
     }
+    CHECK_REF(143, self, self_Refman)
+    CHECK_REF(143, self, self_Refman)
     CHECK_REF(142, self, self_Refman)
+    CHECK_REF(142, self, self_Refman)
+    if (((! (self->_base.parent != NULL && self->_base.parent_Refman->value != NULL)) && (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL))) && ((self->access == tl5_compiler_M_Access_USER) || (self->access == tl5_compiler_M_Access_TEMP))) {
+        INIT_STRING_CONST(145, aux_String_3, "global variables cannot have access");
+        CHECK_REF(146, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(146, self, self_Refman)
+        CHECK_REF(146, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
+        if ((self->access) < 0 || (self->access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(146, slice_index)
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_3, aux_String_3_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + self->access, tl5_compiler_M_glob->access_names_Refman);
+        CHECK(144)
+    }
+    CHECK_REF(147, self, self_Refman)
     if (self->parent_type != NULL && self->parent_type_Refman->value != NULL) {
-        CHECK_REF(143, self, self_Refman)
-        CHECK_REF(143, self, self_Refman)
-        if ((self->access == tl5_compiler_M_Access_USER) || (self->access == tl5_compiler_M_Access_TEMP)) {
-            INIT_STRING_CONST(145, aux_String_3, "fields cannot have access");
-            CHECK_REF(146, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-            CHECK_REF(146, self, self_Refman)
-            CHECK_REF(146, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
-            if ((self->access) < 0 || (self->access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(146, slice_index)
-            LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_3, aux_String_3_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + self->access, tl5_compiler_M_glob->access_names_Refman);
-            CHECK(144)
-        }
-        CHECK_REF(149, self, self_Refman)
-        CHECK_REF(149, self->parent_type, self->parent_type_Refman)
-        CHECK_REF(148, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
         CHECK_REF(148, self, self_Refman)
-        CHECK_REF(148, self->type_instance, self->type_instance_Refman)
-        CHECK_REF(147, self, self_Refman)
-        CHECK_REF(147, self->type_instance, self->type_instance_Refman)
-        CHECK_REF(147, self->type_instance->type_data, self->type_instance->type_data_Refman)
+        CHECK_REF(148, self, self_Refman)
+        if ((self->access == tl5_compiler_M_Access_USER) || (self->access == tl5_compiler_M_Access_TEMP)) {
+            INIT_STRING_CONST(150, aux_String_4, "fields cannot have access");
+            CHECK_REF(151, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+            CHECK_REF(151, self, self_Refman)
+            CHECK_REF(151, tl5_compiler_M_glob->access_names, tl5_compiler_M_glob->access_names_Refman)
+            if ((self->access) < 0 || (self->access) >= (tl5_compiler_M_glob->access_names)->length) RAISE(151, slice_index)
+            LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_4, aux_String_4_Refman, ((String*)((tl5_compiler_M_glob->access_names)->values)) + self->access, tl5_compiler_M_glob->access_names_Refman);
+            CHECK(149)
+        }
+        CHECK_REF(154, self, self_Refman)
+        CHECK_REF(154, self->parent_type, self->parent_type_Refman)
+        CHECK_REF(153, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(153, self, self_Refman)
+        CHECK_REF(153, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(152, self, self_Refman)
+        CHECK_REF(152, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(152, self->type_instance->type_data, self->type_instance->type_data_Refman)
         if (((! self->type_instance->type_data->is_primitive) || ((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_func)) && (! (self->parent_type->constructor != NULL && self->parent_type->constructor_Refman->value != NULL))) {
-            CHECK_REF(150, self, self_Refman)
+            CHECK_REF(155, self, self_Refman)
             LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_2));
-            CHECK(150)
+            CHECK(155)
             if (aux_Bool_2) {
-                CHECK_REF(151, self, self_Refman)
-                CHECK_REF(151, self->type_instance, self->type_instance_Refman)
-                CHECK_REF(151, self->type_instance->type_data, self->type_instance->type_data_Refman)
+                CHECK_REF(156, self, self_Refman)
+                CHECK_REF(156, self->type_instance, self->type_instance_Refman)
+                CHECK_REF(156, self->type_instance->type_data, self->type_instance->type_data_Refman)
                 if (self->type_instance->type_data->constructor != NULL && self->type_instance->type_data->constructor_Refman->value != NULL) {
-                    INIT_STRING_CONST(154, aux_String_4, "variable with constructor in type without constructor");
-                    CHECK_REF(155, self, self_Refman)
-                    CHECK_REF(155, self->parent_type, self->parent_type_Refman)
-                    LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_4, aux_String_4_Refman, self->parent_type->name, self->parent_type->name_Refman);
-                    CHECK(152)
+                    INIT_STRING_CONST(159, aux_String_5, "variable with constructor in type without constructor");
+                    CHECK_REF(160, self, self_Refman)
+                    CHECK_REF(160, self->parent_type, self->parent_type_Refman)
+                    LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_5, aux_String_5_Refman, self->parent_type->name, self->parent_type->name_Refman);
+                    CHECK(157)
                 }
             }
             else {
-                    CHECK_REF(156, self, self_Refman)
-                    CHECK_REF(156, self->type_instance, self->type_instance_Refman)
+                    CHECK_REF(161, self, self_Refman)
+                    CHECK_REF(161, self->type_instance, self->type_instance_Refman)
                     if (! self->type_instance->conditional) {
-                        INIT_STRING_CONST(159, aux_String_5, "non-conditional reference in type without constructor");
-                        CHECK_REF(160, self, self_Refman)
-                        CHECK_REF(160, self->parent_type, self->parent_type_Refman)
-                        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_5, aux_String_5_Refman, self->parent_type->name, self->parent_type->name_Refman);
-                        CHECK(157)
+                        INIT_STRING_CONST(164, aux_String_6, "non-conditional reference in type without constructor");
+                        CHECK_REF(165, self, self_Refman)
+                        CHECK_REF(165, self->parent_type, self->parent_type_Refman)
+                        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_6, aux_String_6_Refman, self->parent_type->name, self->parent_type->name_Refman);
+                        CHECK(162)
                     }
                 }
         }
     }
-    CHECK_REF(161, self, self_Refman)
+    CHECK_REF(166, self, self_Refman)
     if (self->my_module != NULL && self->my_module_Refman->value != NULL) {
-        CHECK_REF(162, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(167, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
         aux_Ref_Manager = tl5_compiler_M_glob->current_module_Refman;
         tl5_compiler_M_glob->current_module_Refman = NULL;
         LUMI_inc_ref(tl5_compiler_M_glob->current_module_Refman);
@@ -42030,6 +42046,7 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_analyze(tl5_compiler_M_SyntaxTreeVa
         tl5_compiler_M_glob->current_module = NULL;
     }
 LUMI_cleanup:
+    LUMI_var_dec_ref(aux_String_6_Refman);
     LUMI_var_dec_ref(aux_String_5_Refman);
     LUMI_var_dec_ref(aux_String_4_Refman);
     LUMI_var_dec_ref(aux_String_3_Refman);
@@ -42062,7 +42079,7 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_check_memory(tl5_compiler_M_SyntaxT
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(refs_Refman);
     LUMI_err = tl5_compiler_M_ReferenceMemoryList_add(refs, refs_Refman, self, self_Refman, self_Dynamic);
-    CHECK(168)
+    CHECK(173)
 LUMI_cleanup:
     LUMI_dec_ref(refs_Refman);
     LUMI_dec_ref(self_Refman);
@@ -42076,15 +42093,15 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_SyntaxTreeVariable_write_cname(tl5_compiler_M_SyntaxTreeVariable* self, Ref_Manager* self_Refman, tl5_compiler_M_SyntaxTreeVariable_Dynamic* self_Dynamic) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(171, self, self_Refman)
+    CHECK_REF(176, self, self_Refman)
     if (self->my_module != NULL && self->my_module_Refman->value != NULL) {
-        CHECK_REF(172, self, self_Refman)
+        CHECK_REF(177, self, self_Refman)
         LUMI_err = tl5_compiler_M_ModuleMembers_write_prefix(self->my_module, self->my_module_Refman);
-        CHECK(172)
+        CHECK(177)
     }
-    CHECK_REF(173, self, self_Refman)
+    CHECK_REF(178, self, self_Refman)
     LUMI_err = tl5_compiler_M_write_cname(self->name, self->name_Refman);
-    CHECK(173)
+    CHECK(178)
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
     return LUMI_err;
@@ -42119,118 +42136,118 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write(tl5_compiler_M_SyntaxTreeVari
     Bool aux_Bool_2 = 0;
     Bool aux_Bool_3 = 0;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(176, self, self_Refman)
-    CHECK_REF(176, self, self_Refman)
+    CHECK_REF(181, self, self_Refman)
+    CHECK_REF(181, self, self_Refman)
     if ((self->_base.parent != NULL && self->_base.parent_Refman->value != NULL) || (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-        CHECK(177)
+        CHECK(182)
     }
     else {
-            CHECK_REF(178, self, self_Refman)
+            CHECK_REF(183, self, self_Refman)
             if (! self->is_native) {
-                INIT_STRING_CONST(179, aux_String_0, "\n");
+                INIT_STRING_CONST(184, aux_String_0, "\n");
                 LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-                CHECK(179)
+                CHECK(184)
             }
         }
-    CHECK_REF(182, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(182, self, self_Refman)
-    CHECK_REF(182, self->type_instance, self->type_instance_Refman)
-    CHECK_REF(181, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(181, self, self_Refman)
-    CHECK_REF(181, self->type_instance, self->type_instance_Refman)
-    if (((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_array) || ((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_string)) {
-        LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_sequence(self, self_Refman, self_Dynamic);
-        CHECK(183)
-        goto LUMI_cleanup;
-    }
+    CHECK_REF(187, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     CHECK_REF(187, self, self_Refman)
-    CHECK_REF(187, self, self_Refman)
-    LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_0));
-    CHECK(186)
+    CHECK_REF(187, self->type_instance, self->type_instance_Refman)
+    CHECK_REF(186, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     CHECK_REF(186, self, self_Refman)
     CHECK_REF(186, self->type_instance, self->type_instance_Refman)
-    CHECK_REF(186, self->type_instance->type_data, self->type_instance->type_data_Refman)
+    if (((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_array) || ((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_string)) {
+        LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_sequence(self, self_Refman, self_Dynamic);
+        CHECK(188)
+        goto LUMI_cleanup;
+    }
+    CHECK_REF(192, self, self_Refman)
+    CHECK_REF(192, self, self_Refman)
+    LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_0));
+    CHECK(191)
+    CHECK_REF(191, self, self_Refman)
+    CHECK_REF(191, self->type_instance, self->type_instance_Refman)
+    CHECK_REF(191, self->type_instance->type_data, self->type_instance->type_data_Refman)
     if (((! self->type_instance->type_data->is_primitive) && aux_Bool_0) && (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL))) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_var(self, self_Refman, self_Dynamic);
-        CHECK(188)
+        CHECK(193)
     }
-    CHECK_REF(193, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(193, self, self_Refman)
-    CHECK_REF(193, self->type_instance, self->type_instance_Refman)
+    CHECK_REF(198, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(198, self, self_Refman)
+    CHECK_REF(198, self->type_instance, self->type_instance_Refman)
     if ((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_func) {
-        CHECK_REF(194, self, self_Refman)
-        CHECK_REF(194, self->type_instance, self->type_instance_Refman)
-        CHECK_REF(194, self, self_Refman)
+        CHECK_REF(199, self, self_Refman)
+        CHECK_REF(199, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(199, self, self_Refman)
         LUMI_err = tl5_compiler_M_FunctionArguments_write_pointer(self->type_instance->arguments, self->type_instance->arguments_Refman, self->type_instance->arguments_Dynamic, self->name, self->name_Refman);
-        CHECK(194)
+        CHECK(199)
     }
     else {
-            CHECK_REF(196, self, self_Refman)
+            CHECK_REF(201, self, self_Refman)
             LUMI_err = tl5_compiler_M_TypeInstance_write_cname(self->type_instance, self->type_instance_Refman);
-            CHECK(196)
-            CHECK_REF(199, self, self_Refman)
-            LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_1));
-            CHECK(197)
-            CHECK_REF(198, self, self_Refman)
-            CHECK_REF(197, self, self_Refman)
-            CHECK_REF(197, self->type_instance, self->type_instance_Refman)
-            CHECK_REF(197, self->type_instance->type_data, self->type_instance->type_data_Refman)
-            if ((! self->type_instance->type_data->is_primitive) && (! ((self->parent_type != NULL && self->parent_type_Refman->value != NULL) && aux_Bool_1))) {
-            INIT_STRING_CONST(200, aux_String_1, "*");
-            LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-            CHECK(200)
-        }
-            INIT_STRING_CONST(201, aux_String_2, " ");
-            LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
             CHECK(201)
-            if (self_Dynamic == NULL) RAISE(202, empty_object)
-            LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+            CHECK_REF(204, self, self_Refman)
+            LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_1));
             CHECK(202)
+            CHECK_REF(203, self, self_Refman)
+            CHECK_REF(202, self, self_Refman)
+            CHECK_REF(202, self->type_instance, self->type_instance_Refman)
+            CHECK_REF(202, self->type_instance->type_data, self->type_instance->type_data_Refman)
+            if ((! self->type_instance->type_data->is_primitive) && (! ((self->parent_type != NULL && self->parent_type_Refman->value != NULL) && aux_Bool_1))) {
+            INIT_STRING_CONST(205, aux_String_1, "*");
+            LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
+            CHECK(205)
         }
-    CHECK_REF(204, self, self_Refman)
-    CHECK_REF(204, self, self_Refman)
+            INIT_STRING_CONST(206, aux_String_2, " ");
+            LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
+            CHECK(206)
+            if (self_Dynamic == NULL) RAISE(207, empty_object)
+            LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+            CHECK(207)
+        }
+    CHECK_REF(209, self, self_Refman)
+    CHECK_REF(209, self, self_Refman)
     if ((! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) && (! self->is_native)) {
-        CHECK_REF(207, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(207, self, self_Refman)
-        CHECK_REF(207, self->type_instance, self->type_instance_Refman)
-        CHECK_REF(206, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(206, self, self_Refman)
-        CHECK_REF(206, self->type_instance, self->type_instance_Refman)
-        CHECK_REF(205, self, self_Refman)
-        CHECK_REF(205, self->type_instance, self->type_instance_Refman)
-        CHECK_REF(205, self->type_instance->type_data, self->type_instance->type_data_Refman)
+        CHECK_REF(212, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(212, self, self_Refman)
+        CHECK_REF(212, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(211, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(211, self, self_Refman)
+        CHECK_REF(211, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(210, self, self_Refman)
+        CHECK_REF(210, self->type_instance, self->type_instance_Refman)
+        CHECK_REF(210, self->type_instance->type_data, self->type_instance->type_data_Refman)
         if ((self->type_instance->type_data->is_primitive && ((void*)self->type_instance->type_data != tl5_compiler_M_glob->type_func)) && ((void*)self->type_instance->type_data != tl5_compiler_M_glob->type_ref)) {
-            INIT_STRING_CONST(208, aux_String_3, " = 0");
+            INIT_STRING_CONST(213, aux_String_3, " = 0");
             LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
-            CHECK(208)
+            CHECK(213)
         }
         else {
-                INIT_STRING_CONST(210, aux_String_4, " = NULL");
+                INIT_STRING_CONST(215, aux_String_4, " = NULL");
                 LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
-                CHECK(210)
+                CHECK(215)
             }
     }
-    INIT_STRING_CONST(212, aux_String_5, ";\n");
+    INIT_STRING_CONST(217, aux_String_5, ";\n");
     LUMI_err = tl5_compiler_M_write(aux_String_5, aux_String_5_Refman);
-    CHECK(212)
-    CHECK_REF(214, self, self_Refman)
+    CHECK(217)
+    CHECK_REF(219, self, self_Refman)
     LUMI_err = tl5_compiler_M_access_has_refman(self->access, &(aux_Bool_2));
-    CHECK(214)
+    CHECK(219)
     if (aux_Bool_2) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_refman(self, self_Refman, self_Dynamic);
-        CHECK(215)
+        CHECK(220)
     }
-    CHECK_REF(218, self, self_Refman)
+    CHECK_REF(223, self, self_Refman)
     LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_3));
-    CHECK(217)
-    CHECK_REF(218, self, self_Refman)
-    CHECK_REF(217, self, self_Refman)
-    CHECK_REF(217, self->type_instance, self->type_instance_Refman)
-    CHECK_REF(217, self->type_instance->type_data, self->type_instance->type_data_Refman)
+    CHECK(222)
+    CHECK_REF(223, self, self_Refman)
+    CHECK_REF(222, self, self_Refman)
+    CHECK_REF(222, self->type_instance, self->type_instance_Refman)
+    CHECK_REF(222, self->type_instance->type_data, self->type_instance->type_data_Refman)
     if (self->type_instance->type_data->is_dynamic && (! ((self->parent_type != NULL && self->parent_type_Refman->value != NULL) && aux_Bool_3))) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_dynamic(self, self_Refman, self_Dynamic);
-        CHECK(219)
+        CHECK(224)
     }
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_5_Refman);
@@ -42367,280 +42384,280 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write_sequence(tl5_compiler_M_Synta
     Bool aux_Bool_1 = 0;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(227, self, self_Refman)
-    CHECK_REF(227, self, self_Refman)
+    CHECK_REF(232, self, self_Refman)
+    CHECK_REF(232, self, self_Refman)
     LUMI_err = tl5_compiler_M_access_is_only_var(self->access, &(aux_Bool_0));
-    CHECK(226)
-    is_new_or_aux_var = aux_Bool_0 && self->is_create;
-    CHECK_REF(228, self, self_Refman)
-    is_new_var = is_new_or_aux_var && (! self->is_aux);
-    CHECK_REF(231, self, self_Refman)
-    LUMI_err = tl5_compiler_M_TypeInstance_get_array_data_type_depth(self->type_instance, self->type_instance_Refman, &(data_type), &(data_type_Refman), &(sequence_depth));
     CHECK(231)
-    CHECK_REF(233, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(233, data_type, data_type_Refman)
+    is_new_or_aux_var = aux_Bool_0 && self->is_create;
+    CHECK_REF(233, self, self_Refman)
+    is_new_var = is_new_or_aux_var && (! self->is_aux);
+    CHECK_REF(236, self, self_Refman)
+    LUMI_err = tl5_compiler_M_TypeInstance_get_array_data_type_depth(self->type_instance, self->type_instance_Refman, &(data_type), &(data_type_Refman), &(sequence_depth));
+    CHECK(236)
+    CHECK_REF(238, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(238, data_type, data_type_Refman)
     if ((void*)data_type->type_data == tl5_compiler_M_glob->type_string) {
-        INIT_STRING_CONST(234, aux_String_0, "char");
+        INIT_STRING_CONST(239, aux_String_0, "char");
         LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-        CHECK(234)
+        CHECK(239)
     }
     else {
-            CHECK_REF(235, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-            CHECK_REF(235, data_type, data_type_Refman)
+            CHECK_REF(240, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+            CHECK_REF(240, data_type, data_type_Refman)
             if ((void*)data_type->type_data == tl5_compiler_M_glob->type_func) {
-                CHECK_REF(236, data_type, data_type_Refman)
+                CHECK_REF(241, data_type, data_type_Refman)
                 LUMI_err = tl5_compiler_M_FunctionArguments_write_pointer_start(data_type->arguments, data_type->arguments_Refman, data_type->arguments_Dynamic);
-                CHECK(236)
+                CHECK(241)
             }
             else {
                 LUMI_err = tl5_compiler_M_TypeInstance_write_cname(data_type, data_type_Refman);
-                CHECK(238)
+                CHECK(243)
             }
         }
     if (! is_new_var) {
-        INIT_STRING_CONST(240, aux_String_1, "*");
+        INIT_STRING_CONST(245, aux_String_1, "*");
         LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-        CHECK(240)
-    }
-    CHECK_REF(241, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(241, data_type, data_type_Refman)
-    if ((void*)data_type->type_data != tl5_compiler_M_glob->type_func) {
-        INIT_STRING_CONST(242, aux_String_2, " ");
-        LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-        CHECK(242)
-    }
-    if (self_Dynamic == NULL) RAISE(243, empty_object)
-    LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
-    CHECK(243)
-    if (is_new_var) {
-        INIT_STRING_CONST(245, aux_String_3, "[");
-        LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
         CHECK(245)
-        CHECK_REF(246, self, self_Refman)
+    }
+    CHECK_REF(246, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(246, data_type, data_type_Refman)
+    if ((void*)data_type->type_data != tl5_compiler_M_glob->type_func) {
+        INIT_STRING_CONST(247, aux_String_2, " ");
+        LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
+        CHECK(247)
+    }
+    if (self_Dynamic == NULL) RAISE(248, empty_object)
+    LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+    CHECK(248)
+    if (is_new_var) {
+        INIT_STRING_CONST(250, aux_String_3, "[");
+        LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
+        CHECK(250)
+        CHECK_REF(251, self, self_Refman)
         sequence_type = self->type_instance;
         sequence_type_Refman = self->type_instance_Refman;
         LUMI_inc_ref(sequence_type_Refman);
-        CHECK_REF(247, sequence_type, sequence_type_Refman)
-        if (sequence_type->length_Dynamic == NULL) RAISE(247, empty_object)
+        CHECK_REF(252, sequence_type, sequence_type_Refman)
+        if (sequence_type->length_Dynamic == NULL) RAISE(252, empty_object)
         LUMI_err = sequence_type->length_Dynamic->_base.write(&(sequence_type->length->_base), sequence_type->length_Refman, &(sequence_type->length_Dynamic->_base));
-        CHECK(247)
+        CHECK(252)
         for (_ = 0; _ < sequence_depth; ++_) {
-            CHECK_REF(249, sequence_type, sequence_type_Refman)
-            CHECK_REF(249, sequence_type->parameters, sequence_type->parameters_Refman)
-            CHECK_REF(249, sequence_type->parameters->first, sequence_type->parameters->first_Refman)
+            CHECK_REF(254, sequence_type, sequence_type_Refman)
+            CHECK_REF(254, sequence_type->parameters, sequence_type->parameters_Refman)
+            CHECK_REF(254, sequence_type->parameters->first, sequence_type->parameters->first_Refman)
             aux_Ref_Manager = sequence_type_Refman;
             sequence_type_Refman = sequence_type->parameters->first->item_Refman;
             LUMI_inc_ref(sequence_type_Refman);
             LUMI_dec_ref(aux_Ref_Manager);
             aux_Ref_Manager = NULL;
             sequence_type = sequence_type->parameters->first->item;
-            INIT_STRING_CONST(250, aux_String_4, " * ");
+            INIT_STRING_CONST(255, aux_String_4, " * ");
             LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
-            CHECK(250)
-            CHECK_REF(251, sequence_type, sequence_type_Refman)
-            if (sequence_type->length_Dynamic == NULL) RAISE(251, empty_object)
+            CHECK(255)
+            CHECK_REF(256, sequence_type, sequence_type_Refman)
+            if (sequence_type->length_Dynamic == NULL) RAISE(256, empty_object)
             LUMI_err = sequence_type->length_Dynamic->_base.write(&(sequence_type->length->_base), sequence_type->length_Refman, &(sequence_type->length_Dynamic->_base));
-            CHECK(251)
+            CHECK(256)
         }
-        INIT_STRING_CONST(252, aux_String_5, "]");
+        INIT_STRING_CONST(257, aux_String_5, "]");
         LUMI_err = tl5_compiler_M_write(aux_String_5, aux_String_5_Refman);
-        CHECK(252)
-    }
-    CHECK_REF(253, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(253, data_type, data_type_Refman)
-    if ((void*)data_type->type_data == tl5_compiler_M_glob->type_func) {
-        INIT_STRING_CONST(254, aux_String_6, ")");
-        LUMI_err = tl5_compiler_M_write(aux_String_6, aux_String_6_Refman);
-        CHECK(254)
-        CHECK_REF(255, data_type, data_type_Refman)
-        if (data_type->arguments_Dynamic == NULL) RAISE(255, empty_object)
-        LUMI_err = data_type->arguments_Dynamic->_base.write(&(data_type->arguments->_base), data_type->arguments_Refman, &(data_type->arguments_Dynamic->_base));
-        CHECK(255)
-    }
-    CHECK_REF(256, self, self_Refman)
-    if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
-        INIT_STRING_CONST(257, aux_String_7, " = ");
-        LUMI_err = tl5_compiler_M_write(aux_String_7, aux_String_7_Refman);
         CHECK(257)
+    }
+    CHECK_REF(258, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(258, data_type, data_type_Refman)
+    if ((void*)data_type->type_data == tl5_compiler_M_glob->type_func) {
+        INIT_STRING_CONST(259, aux_String_6, ")");
+        LUMI_err = tl5_compiler_M_write(aux_String_6, aux_String_6_Refman);
+        CHECK(259)
+        CHECK_REF(260, data_type, data_type_Refman)
+        if (data_type->arguments_Dynamic == NULL) RAISE(260, empty_object)
+        LUMI_err = data_type->arguments_Dynamic->_base.write(&(data_type->arguments->_base), data_type->arguments_Refman, &(data_type->arguments_Dynamic->_base));
+        CHECK(260)
+    }
+    CHECK_REF(261, self, self_Refman)
+    if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
+        INIT_STRING_CONST(262, aux_String_7, " = ");
+        LUMI_err = tl5_compiler_M_write(aux_String_7, aux_String_7_Refman);
+        CHECK(262)
         if (is_new_var) {
-            INIT_STRING_CONST(259, aux_String_8, "{0}");
+            INIT_STRING_CONST(264, aux_String_8, "{0}");
             LUMI_err = tl5_compiler_M_write(aux_String_8, aux_String_8_Refman);
-            CHECK(259)
+            CHECK(264)
         }
         else {
-                INIT_STRING_CONST(261, aux_String_9, "NULL");
+                INIT_STRING_CONST(266, aux_String_9, "NULL");
                 LUMI_err = tl5_compiler_M_write(aux_String_9, aux_String_9_Refman);
-                CHECK(261)
+                CHECK(266)
             }
     }
-    INIT_STRING_CONST(262, aux_String_10, ";\n");
+    INIT_STRING_CONST(267, aux_String_10, ";\n");
     LUMI_err = tl5_compiler_M_write(aux_String_10, aux_String_10_Refman);
-    CHECK(262)
+    CHECK(267)
     if (! is_new_var) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-        CHECK(267)
-        INIT_STRING_CONST(268, aux_String_11, "int");
+        CHECK(272)
+        INIT_STRING_CONST(273, aux_String_11, "int");
         LUMI_err = tl5_compiler_M_write(aux_String_11, aux_String_11_Refman);
-        CHECK(268)
-        INIT_STRING_CONST(269, aux_String_12, " ");
+        CHECK(273)
+        INIT_STRING_CONST(274, aux_String_12, " ");
         LUMI_err = tl5_compiler_M_write(aux_String_12, aux_String_12_Refman);
-        CHECK(269)
-        if (self_Dynamic == NULL) RAISE(270, empty_object)
+        CHECK(274)
+        if (self_Dynamic == NULL) RAISE(275, empty_object)
         LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
-        CHECK(270)
-        INIT_STRING_CONST(271, aux_String_13, "_");
+        CHECK(275)
+        INIT_STRING_CONST(276, aux_String_13, "_");
         LUMI_err = tl5_compiler_M_write(aux_String_13, aux_String_13_Refman);
-        CHECK(271)
-        CHECK_REF(272, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-        CHECK_REF(272, self, self_Refman)
-        CHECK_REF(272, self->type_instance, self->type_instance_Refman)
+        CHECK(276)
+        CHECK_REF(277, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(277, self, self_Refman)
+        CHECK_REF(277, self->type_instance, self->type_instance_Refman)
         if ((void*)self->type_instance->type_data == tl5_compiler_M_glob->type_string) {
-            INIT_STRING_CONST(273, aux_String_14, "Max_length");
+            INIT_STRING_CONST(278, aux_String_14, "Max_length");
             LUMI_err = tl5_compiler_M_write(aux_String_14, aux_String_14_Refman);
-            CHECK(273)
+            CHECK(278)
         }
         else {
-                INIT_STRING_CONST(275, aux_String_15, "Length");
+                INIT_STRING_CONST(280, aux_String_15, "Length");
                 LUMI_err = tl5_compiler_M_write(aux_String_15, aux_String_15_Refman);
-                CHECK(275)
+                CHECK(280)
             }
-        CHECK_REF(276, self, self_Refman)
+        CHECK_REF(281, self, self_Refman)
         if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
-            INIT_STRING_CONST(277, aux_String_16, " = 0");
+            INIT_STRING_CONST(282, aux_String_16, " = 0");
             LUMI_err = tl5_compiler_M_write(aux_String_16, aux_String_16_Refman);
-            CHECK(277)
+            CHECK(282)
         }
-        INIT_STRING_CONST(278, aux_String_17, ";\n");
+        INIT_STRING_CONST(283, aux_String_17, ";\n");
         LUMI_err = tl5_compiler_M_write(aux_String_17, aux_String_17_Refman);
-        CHECK(278)
+        CHECK(283)
         for (depth = 0; depth < sequence_depth; ++depth) {
             LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-            CHECK(282)
-            INIT_STRING_CONST(283, aux_String_18, "int ");
+            CHECK(287)
+            INIT_STRING_CONST(288, aux_String_18, "int ");
             LUMI_err = tl5_compiler_M_write(aux_String_18, aux_String_18_Refman);
-            CHECK(283)
-            if (self_Dynamic == NULL) RAISE(284, empty_object)
-            LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
-            CHECK(284)
-            LUMI_err = tl5_compiler_M_write_array_value_length(depth);
-            CHECK(285)
-            CHECK_REF(286, self, self_Refman)
-            if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
-                INIT_STRING_CONST(287, aux_String_19, " = 0");
-                LUMI_err = tl5_compiler_M_write(aux_String_19, aux_String_19_Refman);
-                CHECK(287)
-            }
-            INIT_STRING_CONST(288, aux_String_20, ";\n");
-            LUMI_err = tl5_compiler_M_write(aux_String_20, aux_String_20_Refman);
             CHECK(288)
+            if (self_Dynamic == NULL) RAISE(289, empty_object)
+            LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+            CHECK(289)
+            LUMI_err = tl5_compiler_M_write_array_value_length(depth);
+            CHECK(290)
+            CHECK_REF(291, self, self_Refman)
+            if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
+                INIT_STRING_CONST(292, aux_String_19, " = 0");
+                LUMI_err = tl5_compiler_M_write(aux_String_19, aux_String_19_Refman);
+                CHECK(292)
+            }
+            INIT_STRING_CONST(293, aux_String_20, ";\n");
+            LUMI_err = tl5_compiler_M_write(aux_String_20, aux_String_20_Refman);
+            CHECK(293)
         }
     }
-    CHECK_REF(290, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(290, data_type, data_type_Refman)
+    CHECK_REF(295, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(295, data_type, data_type_Refman)
     if ((void*)data_type->type_data == tl5_compiler_M_glob->type_string) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-        CHECK(295)
-        INIT_STRING_CONST(296, aux_String_21, "int");
-        LUMI_err = tl5_compiler_M_write(aux_String_21, aux_String_21_Refman);
-        CHECK(296)
-        if (! is_new_or_aux_var) {
-            INIT_STRING_CONST(298, aux_String_22, "*");
-            LUMI_err = tl5_compiler_M_write(aux_String_22, aux_String_22_Refman);
-            CHECK(298)
-        }
-        INIT_STRING_CONST(299, aux_String_23, " ");
-        LUMI_err = tl5_compiler_M_write(aux_String_23, aux_String_23_Refman);
-        CHECK(299)
-        if (self_Dynamic == NULL) RAISE(300, empty_object)
-        LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
         CHECK(300)
+        INIT_STRING_CONST(301, aux_String_21, "int");
+        LUMI_err = tl5_compiler_M_write(aux_String_21, aux_String_21_Refman);
+        CHECK(301)
+        if (! is_new_or_aux_var) {
+            INIT_STRING_CONST(303, aux_String_22, "*");
+            LUMI_err = tl5_compiler_M_write(aux_String_22, aux_String_22_Refman);
+            CHECK(303)
+        }
+        INIT_STRING_CONST(304, aux_String_23, " ");
+        LUMI_err = tl5_compiler_M_write(aux_String_23, aux_String_23_Refman);
+        CHECK(304)
+        if (self_Dynamic == NULL) RAISE(305, empty_object)
+        LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+        CHECK(305)
         if (sequence_depth > 0) {
-            INIT_STRING_CONST(302, aux_String_24, "_String_length");
+            INIT_STRING_CONST(307, aux_String_24, "_String_length");
             LUMI_err = tl5_compiler_M_write(aux_String_24, aux_String_24_Refman);
-            CHECK(302)
+            CHECK(307)
         }
         else {
-                INIT_STRING_CONST(304, aux_String_25, "_Length");
+                INIT_STRING_CONST(309, aux_String_25, "_Length");
                 LUMI_err = tl5_compiler_M_write(aux_String_25, aux_String_25_Refman);
-                CHECK(304)
+                CHECK(309)
             }
         if (is_new_or_aux_var) {
-            INIT_STRING_CONST(306, aux_String_26, "[");
+            INIT_STRING_CONST(311, aux_String_26, "[");
             LUMI_err = tl5_compiler_M_write(aux_String_26, aux_String_26_Refman);
-            CHECK(306)
+            CHECK(311)
             if (sequence_depth > 0) {
-                CHECK_REF(308, self, self_Refman)
+                CHECK_REF(313, self, self_Refman)
                 aux_Ref_Manager = sequence_type_Refman;
                 sequence_type_Refman = self->type_instance_Refman;
                 LUMI_inc_ref(sequence_type_Refman);
                 LUMI_dec_ref(aux_Ref_Manager);
                 aux_Ref_Manager = NULL;
                 sequence_type = self->type_instance;
-                CHECK_REF(309, sequence_type, sequence_type_Refman)
-                if (sequence_type->length_Dynamic == NULL) RAISE(309, empty_object)
+                CHECK_REF(314, sequence_type, sequence_type_Refman)
+                if (sequence_type->length_Dynamic == NULL) RAISE(314, empty_object)
                 LUMI_err = sequence_type->length_Dynamic->_base.write(&(sequence_type->length->_base), sequence_type->length_Refman, &(sequence_type->length_Dynamic->_base));
-                CHECK(309)
+                CHECK(314)
                 for (_ = 0; _ < sequence_depth - 1; ++_) {
-                    CHECK_REF(311, sequence_type, sequence_type_Refman)
-                    CHECK_REF(311, sequence_type->parameters, sequence_type->parameters_Refman)
-                    CHECK_REF(311, sequence_type->parameters->first, sequence_type->parameters->first_Refman)
+                    CHECK_REF(316, sequence_type, sequence_type_Refman)
+                    CHECK_REF(316, sequence_type->parameters, sequence_type->parameters_Refman)
+                    CHECK_REF(316, sequence_type->parameters->first, sequence_type->parameters->first_Refman)
                     aux_Ref_Manager = sequence_type_Refman;
                     sequence_type_Refman = sequence_type->parameters->first->item_Refman;
                     LUMI_inc_ref(sequence_type_Refman);
                     LUMI_dec_ref(aux_Ref_Manager);
                     aux_Ref_Manager = NULL;
                     sequence_type = sequence_type->parameters->first->item;
-                    INIT_STRING_CONST(312, aux_String_27, " * ");
+                    INIT_STRING_CONST(317, aux_String_27, " * ");
                     LUMI_err = tl5_compiler_M_write(aux_String_27, aux_String_27_Refman);
-                    CHECK(312)
-                    CHECK_REF(313, sequence_type, sequence_type_Refman)
-                    if (sequence_type->length_Dynamic == NULL) RAISE(313, empty_object)
+                    CHECK(317)
+                    CHECK_REF(318, sequence_type, sequence_type_Refman)
+                    if (sequence_type->length_Dynamic == NULL) RAISE(318, empty_object)
                     LUMI_err = sequence_type->length_Dynamic->_base.write(&(sequence_type->length->_base), sequence_type->length_Refman, &(sequence_type->length_Dynamic->_base));
-                    CHECK(313)
+                    CHECK(318)
                 }
             }
             else {
-                    INIT_STRING_CONST(315, aux_String_28, "1");
+                    INIT_STRING_CONST(320, aux_String_28, "1");
                     LUMI_err = tl5_compiler_M_write(aux_String_28, aux_String_28_Refman);
-                    CHECK(315)
+                    CHECK(320)
                 }
-            INIT_STRING_CONST(316, aux_String_29, "]");
+            INIT_STRING_CONST(321, aux_String_29, "]");
             LUMI_err = tl5_compiler_M_write(aux_String_29, aux_String_29_Refman);
-            CHECK(316)
+            CHECK(321)
         }
-        CHECK_REF(317, self, self_Refman)
+        CHECK_REF(322, self, self_Refman)
         if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
-            INIT_STRING_CONST(318, aux_String_30, " = ");
+            INIT_STRING_CONST(323, aux_String_30, " = ");
             LUMI_err = tl5_compiler_M_write(aux_String_30, aux_String_30_Refman);
-            CHECK(318)
+            CHECK(323)
             if (is_new_or_aux_var) {
-                INIT_STRING_CONST(320, aux_String_31, "{0}");
+                INIT_STRING_CONST(325, aux_String_31, "{0}");
                 LUMI_err = tl5_compiler_M_write(aux_String_31, aux_String_31_Refman);
-                CHECK(320)
+                CHECK(325)
             }
             else {
                     if (sequence_depth == 0) {
-                        INIT_STRING_CONST(322, aux_String_32, "&Lumi_empty_int");
+                        INIT_STRING_CONST(327, aux_String_32, "&Lumi_empty_int");
                         LUMI_err = tl5_compiler_M_write(aux_String_32, aux_String_32_Refman);
-                        CHECK(322)
+                        CHECK(327)
                     }
                     else {
-                        INIT_STRING_CONST(324, aux_String_33, "NULL");
+                        INIT_STRING_CONST(329, aux_String_33, "NULL");
                         LUMI_err = tl5_compiler_M_write(aux_String_33, aux_String_33_Refman);
-                        CHECK(324)
+                        CHECK(329)
                     }
                 }
         }
-        INIT_STRING_CONST(325, aux_String_34, ";\n");
+        INIT_STRING_CONST(330, aux_String_34, ";\n");
         LUMI_err = tl5_compiler_M_write(aux_String_34, aux_String_34_Refman);
-        CHECK(325)
+        CHECK(330)
     }
-    CHECK_REF(327, self, self_Refman)
+    CHECK_REF(332, self, self_Refman)
     LUMI_err = tl5_compiler_M_access_has_refman(self->access, &(aux_Bool_1));
-    CHECK(327)
+    CHECK(332)
     if (aux_Bool_1) {
         LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_refman(self, self_Refman, self_Dynamic);
-        CHECK(328)
+        CHECK(333)
     }
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_34_Refman);
@@ -42719,29 +42736,29 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write_var(tl5_compiler_M_SyntaxTree
     Ref_Manager* aux_String_5_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(332, self, self_Refman)
-    LUMI_err = tl5_compiler_M_TypeInstance_write_cname(self->type_instance, self->type_instance_Refman);
-    CHECK(332)
-    INIT_STRING_CONST(333, aux_String_0, " ");
-    LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(333)
-    if (self_Dynamic == NULL) RAISE(334, empty_object)
-    LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
-    CHECK(334)
-    INIT_STRING_CONST(335, aux_String_1, "_Var = {");
-    LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-    CHECK(335)
     CHECK_REF(337, self, self_Refman)
-    CHECK_REF(337, self->type_instance, self->type_instance_Refman)
+    LUMI_err = tl5_compiler_M_TypeInstance_write_cname(self->type_instance, self->type_instance_Refman);
+    CHECK(337)
+    INIT_STRING_CONST(338, aux_String_0, " ");
+    LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
+    CHECK(338)
+    if (self_Dynamic == NULL) RAISE(339, empty_object)
+    LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+    CHECK(339)
+    INIT_STRING_CONST(340, aux_String_1, "_Var = {");
+    LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
+    CHECK(340)
+    CHECK_REF(342, self, self_Refman)
+    CHECK_REF(342, self->type_instance, self->type_instance_Refman)
     type_data = self->type_instance->type_data;
     type_data_Refman = self->type_instance->type_data_Refman;
     LUMI_inc_ref(type_data_Refman);
     type_data_Dynamic = self->type_instance->type_data_Dynamic;
     while (true) {
-        CHECK_REF(339, type_data, type_data_Refman)
+        CHECK_REF(344, type_data, type_data_Refman)
         if (type_data->base_type != NULL && type_data->base_type_Refman->value != NULL) {
-            CHECK_REF(340, type_data, type_data_Refman)
-            CHECK_REF(340, type_data->base_type, type_data->base_type_Refman)
+            CHECK_REF(345, type_data, type_data_Refman)
+            CHECK_REF(345, type_data->base_type, type_data->base_type_Refman)
             aux_Ref_Manager = type_data_Refman;
             type_data_Refman = type_data->base_type->type_data_Refman;
             type_data_Dynamic = type_data->base_type->type_data_Dynamic;
@@ -42751,21 +42768,21 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write_var(tl5_compiler_M_SyntaxTree
             type_data = type_data->base_type->type_data;
         }
         else {
-                CHECK_REF(343, type_data, type_data_Refman)
-                CHECK_REF(343, type_data->_base._base.variables.first, type_data->_base._base.variables.first_Refman)
+                CHECK_REF(348, type_data, type_data_Refman)
+                CHECK_REF(348, type_data->_base._base.variables.first, type_data->_base._base.variables.first_Refman)
                 variable = type_data->_base._base.variables.first->item;
                 variable_Refman = type_data->_base._base.variables.first->item_Refman;
                 LUMI_inc_ref(variable_Refman);
                 variable_Dynamic = ((tl5_compiler_M_SyntaxTreeVariable_Dynamic*)(type_data->_base._base.variables.first->item_Dynamic));
-                CHECK_REF(345, variable, variable_Refman)
-                CHECK_REF(345, variable->type_instance, variable->type_instance_Refman)
-                CHECK_REF(345, variable->type_instance->type_data, variable->type_instance->type_data_Refman)
-                CHECK_REF(344, variable, variable_Refman)
+                CHECK_REF(350, variable, variable_Refman)
+                CHECK_REF(350, variable->type_instance, variable->type_instance_Refman)
+                CHECK_REF(350, variable->type_instance->type_data, variable->type_instance->type_data_Refman)
+                CHECK_REF(349, variable, variable_Refman)
                 LUMI_err = tl5_compiler_M_access_is_only_var(variable->access, &(aux_Bool_0));
-                CHECK(344)
+                CHECK(349)
                 if (aux_Bool_0 && (! variable->type_instance->type_data->is_primitive)) {
-                CHECK_REF(346, variable, variable_Refman)
-                CHECK_REF(346, variable->type_instance, variable->type_instance_Refman)
+                CHECK_REF(351, variable, variable_Refman)
+                CHECK_REF(351, variable->type_instance, variable->type_instance_Refman)
                 aux_Ref_Manager = type_data_Refman;
                 type_data_Refman = variable->type_instance->type_data_Refman;
                 type_data_Dynamic = variable->type_instance->type_data_Dynamic;
@@ -42779,23 +42796,23 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write_var(tl5_compiler_M_SyntaxTree
                 }
             }
         bases += 1;
-        INIT_STRING_CONST(350, aux_String_2, "{");
+        INIT_STRING_CONST(355, aux_String_2, "{");
         LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-        CHECK(350)
+        CHECK(355)
     }
-    INIT_STRING_CONST(351, aux_String_3, "0");
+    INIT_STRING_CONST(356, aux_String_3, "0");
     LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
-    CHECK(351)
+    CHECK(356)
     for (n = 0; n < bases; ++n) {
-        INIT_STRING_CONST(353, aux_String_4, "}");
+        INIT_STRING_CONST(358, aux_String_4, "}");
         LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
-        CHECK(353)
+        CHECK(358)
     }
-    INIT_STRING_CONST(354, aux_String_5, "};\n");
+    INIT_STRING_CONST(359, aux_String_5, "};\n");
     LUMI_err = tl5_compiler_M_write(aux_String_5, aux_String_5_Refman);
-    CHECK(354)
+    CHECK(359)
     LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-    CHECK(355)
+    CHECK(360)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_5_Refman);
     LUMI_var_dec_ref(aux_String_4_Refman);
@@ -42832,28 +42849,28 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write_refman(tl5_compiler_M_SyntaxT
     Ref_Manager* aux_String_4_Refman = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-    CHECK(358)
-    INIT_STRING_CONST(359, aux_String_0, "Ref_Manager*");
+    CHECK(363)
+    INIT_STRING_CONST(364, aux_String_0, "Ref_Manager*");
     LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(359)
-    INIT_STRING_CONST(360, aux_String_1, " ");
+    CHECK(364)
+    INIT_STRING_CONST(365, aux_String_1, " ");
     LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-    CHECK(360)
-    if (self_Dynamic == NULL) RAISE(361, empty_object)
-    LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
-    CHECK(361)
-    INIT_STRING_CONST(362, aux_String_2, "_Refman");
-    LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-    CHECK(362)
-    CHECK_REF(363, self, self_Refman)
-    if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
-        INIT_STRING_CONST(364, aux_String_3, " = NULL");
-        LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
-        CHECK(364)
-    }
-    INIT_STRING_CONST(365, aux_String_4, ";\n");
-    LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
     CHECK(365)
+    if (self_Dynamic == NULL) RAISE(366, empty_object)
+    LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
+    CHECK(366)
+    INIT_STRING_CONST(367, aux_String_2, "_Refman");
+    LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
+    CHECK(367)
+    CHECK_REF(368, self, self_Refman)
+    if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
+        INIT_STRING_CONST(369, aux_String_3, " = NULL");
+        LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
+        CHECK(369)
+    }
+    INIT_STRING_CONST(370, aux_String_4, ";\n");
+    LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
+    CHECK(370)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_4_Refman);
     LUMI_var_dec_ref(aux_String_3_Refman);
@@ -42893,45 +42910,45 @@ Returncode tl5_compiler_M_SyntaxTreeVariable_write_dynamic(tl5_compiler_M_Syntax
     Ref_Manager* aux_String_6_Refman = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_err = tl5_compiler_M_SyntaxTreeVariable_write_spaces(self, self_Refman, self_Dynamic);
-    CHECK(369)
-    CHECK_REF(370, self, self_Refman)
+    CHECK(374)
+    CHECK_REF(375, self, self_Refman)
     LUMI_err = tl5_compiler_M_TypeInstance_write_cname(self->type_instance, self->type_instance_Refman);
-    CHECK(370)
-    INIT_STRING_CONST(371, aux_String_0, "_Dynamic* ");
+    CHECK(375)
+    INIT_STRING_CONST(376, aux_String_0, "_Dynamic* ");
     LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(371)
-    if (self_Dynamic == NULL) RAISE(372, empty_object)
+    CHECK(376)
+    if (self_Dynamic == NULL) RAISE(377, empty_object)
     LUMI_err = self_Dynamic->write_cname(self, self_Refman, self_Dynamic);
-    CHECK(372)
-    INIT_STRING_CONST(373, aux_String_1, "_Dynamic");
+    CHECK(377)
+    INIT_STRING_CONST(378, aux_String_1, "_Dynamic");
     LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-    CHECK(373)
-    CHECK_REF(374, self, self_Refman)
+    CHECK(378)
+    CHECK_REF(379, self, self_Refman)
     if (! (self->parent_type != NULL && self->parent_type_Refman->value != NULL)) {
-        INIT_STRING_CONST(375, aux_String_2, " = ");
+        INIT_STRING_CONST(380, aux_String_2, " = ");
         LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-        CHECK(375)
-        CHECK_REF(376, self, self_Refman)
+        CHECK(380)
+        CHECK_REF(381, self, self_Refman)
         if (self->is_create) {
-            INIT_STRING_CONST(377, aux_String_3, "&");
+            INIT_STRING_CONST(382, aux_String_3, "&");
             LUMI_err = tl5_compiler_M_write(aux_String_3, aux_String_3_Refman);
-            CHECK(377)
-            CHECK_REF(378, self, self_Refman)
+            CHECK(382)
+            CHECK_REF(383, self, self_Refman)
             LUMI_err = tl5_compiler_M_TypeInstance_write_cname(self->type_instance, self->type_instance_Refman);
-            CHECK(378)
-            INIT_STRING_CONST(379, aux_String_4, "_dynamic");
+            CHECK(383)
+            INIT_STRING_CONST(384, aux_String_4, "_dynamic");
             LUMI_err = tl5_compiler_M_write(aux_String_4, aux_String_4_Refman);
-            CHECK(379)
+            CHECK(384)
         }
         else {
-                INIT_STRING_CONST(381, aux_String_5, "NULL");
+                INIT_STRING_CONST(386, aux_String_5, "NULL");
                 LUMI_err = tl5_compiler_M_write(aux_String_5, aux_String_5_Refman);
-                CHECK(381)
+                CHECK(386)
             }
     }
-    INIT_STRING_CONST(382, aux_String_6, ";\n");
+    INIT_STRING_CONST(387, aux_String_6, ";\n");
     LUMI_err = tl5_compiler_M_write(aux_String_6, aux_String_6_Refman);
-    CHECK(382)
+    CHECK(387)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_6_Refman);
     LUMI_var_dec_ref(aux_String_5_Refman);
@@ -42951,17 +42968,17 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_SyntaxTreeVariable_write_spaces(tl5_compiler_M_SyntaxTreeVariable* self, Ref_Manager* self_Refman, tl5_compiler_M_SyntaxTreeVariable_Dynamic* self_Dynamic) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(385, self, self_Refman)
+    CHECK_REF(390, self, self_Refman)
     if (self->_base.parent != NULL && self->_base.parent_Refman->value != NULL) {
         LUMI_err = tl5_compiler_M_SyntaxTreeCode_write_spaces(&(self->_base), self_Refman, &(self_Dynamic->_base));
-        CHECK(386)
+        CHECK(391)
     }
     else {
-            CHECK_REF(387, self, self_Refman)
+            CHECK_REF(392, self, self_Refman)
             if (self->parent_type != NULL && self->parent_type_Refman->value != NULL) {
-                CHECK_REF(388, self, self_Refman)
+                CHECK_REF(393, self, self_Refman)
                 LUMI_err = tl5_compiler_M_SyntaxTreeBranch_write_spaces(&(self->parent_type->_base._base), self->parent_type_Refman, &(self->parent_type_Dynamic->_base._base));
-                CHECK(388)
+                CHECK(393)
             }
         }
 LUMI_cleanup:
@@ -43120,9 +43137,9 @@ Returncode tl5_compiler_M_SyntaxTreeConstant_parse_new(tl5_compiler_M_SyntaxTree
     Ref_Manager* aux_SyntaxTreeConstant_1_Refman = NULL;
     tl5_compiler_M_SyntaxTreeConstant_Dynamic* aux_SyntaxTreeConstant_1_Dynamic = NULL;
     LUMI_inc_ref(self_Refman);
-    INIT_NEW(480, aux_SyntaxTreeConstant_0, LUMI_alloc(sizeof(tl5_compiler_M_SyntaxTreeConstant)));
+    INIT_NEW(485, aux_SyntaxTreeConstant_0, LUMI_alloc(sizeof(tl5_compiler_M_SyntaxTreeConstant)));
     LUMI_err = tl5_compiler_M_SyntaxTreeCode_new(&(aux_SyntaxTreeConstant_0->_base._base), aux_SyntaxTreeConstant_0_Refman, &(aux_SyntaxTreeConstant_0_Dynamic->_base._base), NULL, NULL, NULL);
-    CHECK(480)
+    CHECK(485)
     aux_SyntaxTreeConstant_1 = aux_SyntaxTreeConstant_0;
     aux_SyntaxTreeConstant_1_Refman = aux_SyntaxTreeConstant_0_Refman;
     aux_SyntaxTreeConstant_1_Dynamic = aux_SyntaxTreeConstant_0_Dynamic;
@@ -43138,7 +43155,7 @@ Returncode tl5_compiler_M_SyntaxTreeConstant_parse_new(tl5_compiler_M_SyntaxTree
     aux_SyntaxTreeConstant_1_Refman = NULL;
     aux_SyntaxTreeConstant_1_Dynamic = NULL;
     LUMI_err = tl5_compiler_M_SyntaxTreeConstant_parse(*constant, *constant_Refman, *constant_Dynamic);
-    CHECK(481)
+    CHECK(486)
 LUMI_cleanup:
     if (aux_SyntaxTreeConstant_1_Dynamic != NULL) aux_SyntaxTreeConstant_1_Dynamic->_base._base._base._del(aux_SyntaxTreeConstant_1);
     LUMI_owner_dec_ref(aux_SyntaxTreeConstant_1_Refman);
@@ -43182,64 +43199,64 @@ Returncode tl5_compiler_M_SyntaxTreeConstant_parse(tl5_compiler_M_SyntaxTreeCons
     Ref_Manager* aux_String_6_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(484, self, self_Refman)
+    CHECK_REF(489, self, self_Refman)
     self->_base.access = tl5_compiler_M_Access_VAR;
-    CHECK_REF(485, self, self_Refman)
+    CHECK_REF(490, self, self_Refman)
     self->_base.constant = true;
-    CHECK_REF(486, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(486, self, self_Refman)
+    CHECK_REF(491, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(491, self, self_Refman)
     aux_Ref_Manager = self->_base.my_module_Refman;
     self->_base.my_module_Refman = tl5_compiler_M_glob->current_module_Refman;
     LUMI_inc_ref(self->_base.my_module_Refman);
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     self->_base.my_module = tl5_compiler_M_glob->current_module;
-    INIT_STRING_CONST(488, aux_String_0, " ");
+    INIT_STRING_CONST(493, aux_String_0, " ");
     LUMI_err = tl5_compiler_M_read_until(aux_String_0, aux_String_0_Refman, false, &(type_name), &(type_name_Refman), &(aux_Int_0));
-    CHECK(488)
-    INIT_STRING_CONST(489, aux_String_1, "Int");
-    LUMI_err = String_equal(type_name, type_name_Refman, aux_String_1, aux_String_1_Refman, &(aux_Bool_0));
-    CHECK(489)
-    if (! aux_Bool_0) {
-        INIT_STRING_CONST(491, aux_String_2, "Only \"Int\" typed constant supported, got");
-        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_2, aux_String_2_Refman, type_name, type_name_Refman);
-        CHECK(490)
-    }
-    INIT_STRING_CONST(493, aux_String_3, "Int");
-    LUMI_err = tl5_compiler_M_SyntaxTreeNode_expect_space(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_3, aux_String_3_Refman);
     CHECK(493)
-    INIT_STRING_CONST(494, aux_String_4, " ");
-    CHECK_REF(494, self, self_Refman)
-    LUMI_err = tl5_compiler_M_read_new(aux_String_4, aux_String_4_Refman, &(self->_base.name), &(self->_base.name_Refman));
+    INIT_STRING_CONST(494, aux_String_1, "Int");
+    LUMI_err = String_equal(type_name, type_name_Refman, aux_String_1, aux_String_1_Refman, &(aux_Bool_0));
     CHECK(494)
-    CHECK_REF(495, self, self_Refman)
-    LUMI_err = tl5_compiler_M_is_legal_name(self->_base.name, self->_base.name_Refman, tl5_compiler_M_NameGroup_CONSTANT, &(aux_Bool_1));
-    CHECK(495)
-    if (! aux_Bool_1) {
-        INIT_STRING_CONST(496, aux_String_5, "illegal constant name");
-        CHECK_REF(496, self, self_Refman)
-        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_5, aux_String_5_Refman, self->_base.name, self->_base.name_Refman);
-        CHECK(496)
+    if (! aux_Bool_0) {
+        INIT_STRING_CONST(496, aux_String_2, "Only \"Int\" typed constant supported, got");
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_2, aux_String_2_Refman, type_name, type_name_Refman);
+        CHECK(495)
     }
-    CHECK_REF(497, self, self_Refman)
-    if (! self->_base.is_native) {
-        CHECK_REF(498, self, self_Refman)
-        LUMI_err = tl5_compiler_M_SyntaxTreeNode_expect_space(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), self->_base.name, self->_base.name_Refman);
-        CHECK(498)
-        CHECK_REF(499, self, self_Refman)
-        INIT_STRING_CONST(499, aux_String_6, "");
-        LUMI_err = tl5_compiler_M_ExpressionValue_new(&(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic, aux_String_6, aux_String_6_Refman, &(self->_base._base), self_Refman, &(self_Dynamic->_base._base));
-        CHECK(499)
-    }
-    CHECK_REF(500, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    INIT_STRING_CONST(498, aux_String_3, "Int");
+    LUMI_err = tl5_compiler_M_SyntaxTreeNode_expect_space(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_3, aux_String_3_Refman);
+    CHECK(498)
+    INIT_STRING_CONST(499, aux_String_4, " ");
+    CHECK_REF(499, self, self_Refman)
+    LUMI_err = tl5_compiler_M_read_new(aux_String_4, aux_String_4_Refman, &(self->_base.name), &(self->_base.name_Refman));
+    CHECK(499)
     CHECK_REF(500, self, self_Refman)
-    LUMI_err = tl5_compiler_M_TypeData_new_type_instance(tl5_compiler_M_glob->type_int, tl5_compiler_M_glob->type_int_Refman, tl5_compiler_M_glob->type_int_Dynamic, &(self->_base.type_instance), &(self->_base.type_instance_Refman));
+    LUMI_err = tl5_compiler_M_is_legal_name(self->_base.name, self->_base.name_Refman, tl5_compiler_M_NameGroup_CONSTANT, &(aux_Bool_1));
     CHECK(500)
-    CHECK_REF(501, self, self_Refman)
-    CHECK_REF(501, self->_base.my_module, self->_base.my_module_Refman)
-    CHECK_REF(501, self, self_Refman)
+    if (! aux_Bool_1) {
+        INIT_STRING_CONST(501, aux_String_5, "illegal constant name");
+        CHECK_REF(501, self, self_Refman)
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_5, aux_String_5_Refman, self->_base.name, self->_base.name_Refman);
+        CHECK(501)
+    }
+    CHECK_REF(502, self, self_Refman)
+    if (! self->_base.is_native) {
+        CHECK_REF(503, self, self_Refman)
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_expect_space(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), self->_base.name, self->_base.name_Refman);
+        CHECK(503)
+        CHECK_REF(504, self, self_Refman)
+        INIT_STRING_CONST(504, aux_String_6, "");
+        LUMI_err = tl5_compiler_M_ExpressionValue_new(&(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic, aux_String_6, aux_String_6_Refman, &(self->_base._base), self_Refman, &(self_Dynamic->_base._base));
+        CHECK(504)
+    }
+    CHECK_REF(505, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(505, self, self_Refman)
+    LUMI_err = tl5_compiler_M_TypeData_new_type_instance(tl5_compiler_M_glob->type_int, tl5_compiler_M_glob->type_int_Refman, tl5_compiler_M_glob->type_int_Dynamic, &(self->_base.type_instance), &(self->_base.type_instance_Refman));
+    CHECK(505)
+    CHECK_REF(506, self, self_Refman)
+    CHECK_REF(506, self->_base.my_module, self->_base.my_module_Refman)
+    CHECK_REF(506, self, self_Refman)
     LUMI_err = tl5_compiler_M_NameMap_add(&(self->_base.my_module->variable_map), self->_base.my_module_Refman, self->_base.name, self->_base.name_Refman, &(self->_base), self_Refman, (void*)&(self_Dynamic->_base));
-    CHECK(501)
+    CHECK(506)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_6_Refman);
     LUMI_var_dec_ref(aux_String_5_Refman);
@@ -43277,37 +43294,37 @@ Returncode tl5_compiler_M_SyntaxTreeConstant_analyze(tl5_compiler_M_SyntaxTreeCo
     Ref_Manager* aux_String_0_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(507, self, self_Refman)
+    CHECK_REF(512, self, self_Refman)
     if (self->analyzed) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(509, self, self_Refman)
+    CHECK_REF(514, self, self_Refman)
     self->analyzed = true;
-    CHECK_REF(510, self, self_Refman)
-    CHECK_REF(510, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(515, self, self_Refman)
+    CHECK_REF(515, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     aux_Ref_Manager = tl5_compiler_M_glob->current_module_Refman;
     tl5_compiler_M_glob->current_module_Refman = self->_base.my_module_Refman;
     LUMI_inc_ref(tl5_compiler_M_glob->current_module_Refman);
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     tl5_compiler_M_glob->current_module = self->_base.my_module;
-    CHECK_REF(511, self, self_Refman)
-    CHECK_REF(511, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(516, self, self_Refman)
+    CHECK_REF(516, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     LUMI_err = tl5_compiler_M_SyntaxTreeNode_analyze_expression(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), &(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic, tl5_compiler_M_glob->type_int, tl5_compiler_M_glob->type_int_Refman, tl5_compiler_M_glob->type_int_Dynamic);
-    CHECK(511)
-    CHECK_REF(512, self, self_Refman)
+    CHECK(516)
+    CHECK_REF(517, self, self_Refman)
     LUMI_err = tl5_compiler_M_ExpressionValue_check_no_error(&(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic);
-    CHECK(512)
-    CHECK_REF(513, self, self_Refman)
-    CHECK_REF(513, self, self_Refman)
+    CHECK(517)
+    CHECK_REF(518, self, self_Refman)
+    CHECK_REF(518, self, self_Refman)
     LUMI_err = tl5_compiler_M_ExpressionValue_get_constant_value(&(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic, &(self->int_value), &(aux_Bool_0));
-    CHECK(513)
+    CHECK(518)
     if (! aux_Bool_0) {
-        INIT_STRING_CONST(514, aux_String_0, "value is not constant");
+        INIT_STRING_CONST(519, aux_String_0, "value is not constant");
         LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error_msg(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_0, aux_String_0_Refman);
-        CHECK(514)
+        CHECK(519)
     }
-    CHECK_REF(515, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(520, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     aux_Ref_Manager = tl5_compiler_M_glob->current_module_Refman;
     tl5_compiler_M_glob->current_module_Refman = NULL;
     LUMI_inc_ref(tl5_compiler_M_glob->current_module_Refman);
@@ -43331,26 +43348,26 @@ Returncode tl5_compiler_M_SyntaxTreeConstant_order_constants(tl5_compiler_M_Synt
     Ref_Manager* aux_String_0_Refman = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(ordered_list_Refman);
-    CHECK_REF(518, self, self_Refman)
+    CHECK_REF(523, self, self_Refman)
     if (self->is_ordered) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(520, self, self_Refman)
-    if (self->ordering) {
-        INIT_STRING_CONST(522, aux_String_0, "recursive dependency in constant");
-        CHECK_REF(522, self, self_Refman)
-        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_0, aux_String_0_Refman, self->_base.name, self->_base.name_Refman);
-        CHECK(521)
-    }
-    CHECK_REF(523, self, self_Refman)
-    self->ordering = true;
-    CHECK_REF(524, self, self_Refman)
-    LUMI_err = tl5_compiler_M_ExpressionValue_order_constants(&(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic, ordered_list, ordered_list_Refman);
-    CHECK(524)
     CHECK_REF(525, self, self_Refman)
+    if (self->ordering) {
+        INIT_STRING_CONST(527, aux_String_0, "recursive dependency in constant");
+        CHECK_REF(527, self, self_Refman)
+        LUMI_err = tl5_compiler_M_SyntaxTreeNode_syntax_error(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base), aux_String_0, aux_String_0_Refman, self->_base.name, self->_base.name_Refman);
+        CHECK(526)
+    }
+    CHECK_REF(528, self, self_Refman)
+    self->ordering = true;
+    CHECK_REF(529, self, self_Refman)
+    LUMI_err = tl5_compiler_M_ExpressionValue_order_constants(&(self->value), self_Refman, &tl5_compiler_M_ExpressionValue_dynamic, ordered_list, ordered_list_Refman);
+    CHECK(529)
+    CHECK_REF(530, self, self_Refman)
     LUMI_err = tl5_compiler_M_NameMap_add(ordered_list, ordered_list_Refman, self->_base.name, self->_base.name_Refman, self, self_Refman, (void*)self_Dynamic);
-    CHECK(525)
-    CHECK_REF(526, self, self_Refman)
+    CHECK(530)
+    CHECK_REF(531, self, self_Refman)
     self->is_ordered = true;
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_0_Refman);
@@ -43366,10 +43383,10 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_SyntaxTreeConstant_get_constant_value(tl5_compiler_M_SyntaxTreeConstant* self, Ref_Manager* self_Refman, tl5_compiler_M_SyntaxTreeConstant_Dynamic* self_Dynamic, Int* value, Bool* has_value) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
-    if (self_Dynamic == NULL) RAISE(529, empty_object)
+    if (self_Dynamic == NULL) RAISE(534, empty_object)
     LUMI_err = self_Dynamic->_base._base._base.analyze(&(self->_base._base._base), self_Refman, &(self_Dynamic->_base._base._base));
-    CHECK(529)
-    CHECK_REF(530, self, self_Refman)
+    CHECK(534)
+    CHECK_REF(535, self, self_Refman)
     *value = self->int_value;
     *has_value = true;
 LUMI_cleanup:
@@ -43393,26 +43410,26 @@ Returncode tl5_compiler_M_SyntaxTreeConstant_write(tl5_compiler_M_SyntaxTreeCons
     String* aux_String_2 = NULL;
     Ref_Manager* aux_String_2_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(534, self, self_Refman)
+    CHECK_REF(539, self, self_Refman)
     if (! self->is_ordered) {
         goto LUMI_cleanup;
     }
-    INIT_STRING_CONST(537, aux_String_0, "\nenum { ");
+    INIT_STRING_CONST(542, aux_String_0, "\nenum { ");
     LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(537)
-    if (self_Dynamic == NULL) RAISE(538, empty_object)
+    CHECK(542)
+    if (self_Dynamic == NULL) RAISE(543, empty_object)
     LUMI_err = self_Dynamic->_base.write_cname(&(self->_base), self_Refman, &(self_Dynamic->_base));
-    CHECK(538)
-    INIT_STRING_CONST(539, aux_String_1, " = ");
+    CHECK(543)
+    INIT_STRING_CONST(544, aux_String_1, " = ");
     LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-    CHECK(539)
-    CHECK_REF(540, self, self_Refman)
+    CHECK(544)
+    CHECK_REF(545, self, self_Refman)
     LUMI_err = tl5_compiler_M_write_int(self->int_value);
-    CHECK(540)
-    INIT_STRING_CONST(541, aux_String_2, " };\n");
+    CHECK(545)
+    INIT_STRING_CONST(546, aux_String_2, " };\n");
     LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
-    CHECK(541)
-    CHECK_REF(542, self, self_Refman)
+    CHECK(546)
+    CHECK_REF(547, self, self_Refman)
     self->is_ordered = false;
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_2_Refman);
@@ -47291,7 +47308,7 @@ Returncode tl5_compiler_M_VariableCreate_new(tl5_compiler_M_VariableCreate* self
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(variable_Refman);
-    CHECK_REF(395, self, self_Refman)
+    CHECK_REF(400, self, self_Refman)
     aux_Ref_Manager = self->variable_Refman;
     self->variable_Refman = variable_Refman;
     self->variable_Dynamic = variable_Dynamic;
@@ -47299,9 +47316,9 @@ Returncode tl5_compiler_M_VariableCreate_new(tl5_compiler_M_VariableCreate* self
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     self->variable = variable;
-    CHECK_REF(396, variable, variable_Refman)
+    CHECK_REF(401, variable, variable_Refman)
     LUMI_err = tl5_compiler_M_SyntaxTreeCode_new(&(self->_base), self_Refman, &(self_Dynamic->_base), variable->_base.parent, variable->_base.parent_Refman, variable->_base.parent_Dynamic);
-    CHECK(396)
+    CHECK(401)
 LUMI_cleanup:
     LUMI_dec_ref(variable_Refman);
     LUMI_dec_ref(self_Refman);
@@ -47315,8 +47332,8 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_VariableCreate_analyze(tl5_compiler_M_VariableCreate* self, Ref_Manager* self_Refman, tl5_compiler_M_VariableCreate_Dynamic* self_Dynamic) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(399, self, self_Refman)
-    CHECK_REF(399, self->variable, self->variable_Refman)
+    CHECK_REF(404, self, self_Refman)
+    CHECK_REF(404, self->variable, self->variable_Refman)
     self->variable->not_declared_yet = false;
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
@@ -47334,18 +47351,18 @@ Returncode tl5_compiler_M_VariableCreate_check_memory(tl5_compiler_M_VariableCre
     Ref_Manager* reference_path_Refman = NULL;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(refs_Refman);
-    CHECK_REF(402, self, self_Refman)
-    INIT_VAR(402, reference_path)
+    CHECK_REF(407, self, self_Refman)
+    INIT_VAR(407, reference_path)
     LUMI_err = tl5_compiler_M_ReferencePath_new(reference_path, reference_path_Refman, self->variable, self->variable_Refman, self->variable_Dynamic);
-    CHECK(402)
-    CHECK_REF(404, self, self_Refman)
-    CHECK_REF(404, self->variable, self->variable_Refman)
-    CHECK_REF(404, self->variable->type_instance, self->variable->type_instance_Refman)
-    CHECK_REF(403, self, self_Refman)
-    CHECK_REF(403, self->variable, self->variable_Refman)
+    CHECK(407)
+    CHECK_REF(409, self, self_Refman)
+    CHECK_REF(409, self->variable, self->variable_Refman)
+    CHECK_REF(409, self->variable->type_instance, self->variable->type_instance_Refman)
+    CHECK_REF(408, self, self_Refman)
+    CHECK_REF(408, self->variable, self->variable_Refman)
     if (self->variable->is_initialized || self->variable->type_instance->conditional) {
         LUMI_err = tl5_compiler_M_ReferenceMemoryList_clear_invalid_reference(refs, refs_Refman, reference_path, reference_path_Refman);
-        CHECK(405)
+        CHECK(410)
     }
 LUMI_cleanup:
     LUMI_var_dec_ref(reference_path_Refman);
@@ -47383,18 +47400,18 @@ Returncode tl5_compiler_M_VariableInit_parse_new(tl5_compiler_M_VariableInit* se
     tl5_compiler_M_VariableInit_Dynamic* new_node_Dynamic = &tl5_compiler_M_VariableInit_dynamic;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(variable_Refman);
-    INIT_NEW(415, new_node, LUMI_alloc(sizeof(tl5_compiler_M_VariableInit)));
+    INIT_NEW(420, new_node, LUMI_alloc(sizeof(tl5_compiler_M_VariableInit)));
     LUMI_err = tl5_compiler_M_VariableCreate_new(&(new_node->_base), new_node_Refman, &(new_node_Dynamic->_base), variable, variable_Refman, variable_Dynamic);
-    CHECK(415)
+    CHECK(420)
     LUMI_err = tl5_compiler_M_VariableInit_parse(new_node, new_node_Refman, new_node_Dynamic);
-    CHECK(416)
-    CHECK_REF(417, variable, variable_Refman)
-    CHECK_REF(417, variable->_base.parent, variable->_base.parent_Refman)
+    CHECK(421)
+    CHECK_REF(422, variable, variable_Refman)
+    CHECK_REF(422, variable->_base.parent, variable->_base.parent_Refman)
     LUMI_err = tl5_compiler_M_List_add(&(variable->_base.parent->code_nodes), variable->_base.parent_Refman, &(new_node->_base._base), new_node_Refman, (void*)&(new_node_Dynamic->_base._base));
     new_node = NULL;
     new_node_Refman = NULL;
     new_node_Dynamic = NULL;
-    CHECK(417)
+    CHECK(422)
 LUMI_cleanup:
     if (new_node_Dynamic != NULL) new_node_Dynamic->_base._base._base._del(new_node);
     LUMI_owner_dec_ref(new_node_Refman);
@@ -47432,16 +47449,16 @@ Returncode tl5_compiler_M_VariableInit_parse(tl5_compiler_M_VariableInit* self, 
     Ref_Manager* aux_ReferencePath_1_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    INIT_NEW(420, aux_InitExpression_0, LUMI_alloc(sizeof(tl5_compiler_M_InitExpression)));
+    INIT_NEW(425, aux_InitExpression_0, LUMI_alloc(sizeof(tl5_compiler_M_InitExpression)));
     LUMI_err = tl5_compiler_M_InitExpression_new(aux_InitExpression_0, aux_InitExpression_0_Refman, aux_InitExpression_0_Dynamic, &(self->_base._base), self_Refman, &(self_Dynamic->_base._base));
-    CHECK(420)
+    CHECK(425)
     aux_InitExpression_1 = aux_InitExpression_0;
     aux_InitExpression_1_Refman = aux_InitExpression_0_Refman;
     aux_InitExpression_1_Dynamic = aux_InitExpression_0_Dynamic;
     aux_InitExpression_0 = NULL;
     aux_InitExpression_0_Refman = NULL;
     aux_InitExpression_0_Dynamic = NULL;
-    CHECK_REF(420, self, self_Refman)
+    CHECK_REF(425, self, self_Refman)
     if (self->expression_init_Dynamic != NULL) self->expression_init_Dynamic->_base._base._base._del(self->expression_init);
     LUMI_owner_dec_ref(self->expression_init_Refman);
     self->expression_init_Refman = aux_InitExpression_1_Refman;
@@ -47451,38 +47468,38 @@ Returncode tl5_compiler_M_VariableInit_parse(tl5_compiler_M_VariableInit* self, 
     aux_InitExpression_1_Refman = NULL;
     aux_InitExpression_1_Dynamic = NULL;
     LUMI_err = tl5_compiler_M_VariableInit_check_error_mark(self, self_Refman, self_Dynamic);
-    CHECK(421)
-    CHECK_REF(422, self, self_Refman)
-    CHECK_REF(423, self, self_Refman)
-    CHECK_REF(423, self->_base.variable, self->_base.variable_Refman)
+    CHECK(426)
+    CHECK_REF(427, self, self_Refman)
+    CHECK_REF(428, self, self_Refman)
+    CHECK_REF(428, self->_base.variable, self->_base.variable_Refman)
     LUMI_err = tl5_compiler_M_TypeInstance_copy_new(self->_base.variable->type_instance, self->_base.variable->type_instance_Refman, &(aux_TypeInstance_0), &(aux_TypeInstance_0_Refman));
-    CHECK(422)
+    CHECK(427)
     LUMI_err = tl5_compiler_M_InitExpression_parse(self->expression_init, self->expression_init_Refman, self->expression_init_Dynamic, aux_TypeInstance_0, aux_TypeInstance_0_Refman, NULL, NULL, NULL);
     aux_TypeInstance_0 = NULL;
     aux_TypeInstance_0_Refman = NULL;
-    CHECK(422)
+    CHECK(427)
     LUMI_err = tl5_compiler_M_VariableInit_check_error_mark(self, self_Refman, self_Dynamic);
-    CHECK(424)
-    CHECK_REF(425, self, self_Refman)
-    CHECK_REF(425, self->expression_init, self->expression_init_Refman)
+    CHECK(429)
+    CHECK_REF(430, self, self_Refman)
+    CHECK_REF(430, self->expression_init, self->expression_init_Refman)
     self->expression_init->_base._base.is_statement = true;
-    CHECK_REF(427, self, self_Refman)
-    CHECK_REF(427, self->_base.variable, self->_base.variable_Refman)
+    CHECK_REF(432, self, self_Refman)
+    CHECK_REF(432, self->_base.variable, self->_base.variable_Refman)
     LUMI_err = tl5_compiler_M_string_new_copy(self->_base.variable->name, self->_base.variable->name_Refman, &(aux_String_0), &(aux_String_0_Refman));
-    CHECK(426)
-    INIT_NEW(426, aux_VariableExpression_0, LUMI_alloc(sizeof(tl5_compiler_M_VariableExpression)));
+    CHECK(431)
+    INIT_NEW(431, aux_VariableExpression_0, LUMI_alloc(sizeof(tl5_compiler_M_VariableExpression)));
     LUMI_err = tl5_compiler_M_VariableExpression_new(aux_VariableExpression_0, aux_VariableExpression_0_Refman, aux_VariableExpression_0_Dynamic, &(self->_base._base), self_Refman, &(self_Dynamic->_base._base), aux_String_0, aux_String_0_Refman);
     aux_String_0 = NULL;
     aux_String_0_Refman = NULL;
-    CHECK(426)
+    CHECK(431)
     aux_VariableExpression_1 = aux_VariableExpression_0;
     aux_VariableExpression_1_Refman = aux_VariableExpression_0_Refman;
     aux_VariableExpression_1_Dynamic = aux_VariableExpression_0_Dynamic;
     aux_VariableExpression_0 = NULL;
     aux_VariableExpression_0_Refman = NULL;
     aux_VariableExpression_0_Dynamic = NULL;
-    CHECK_REF(426, self, self_Refman)
-    CHECK_REF(426, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(431, self, self_Refman)
+    CHECK_REF(431, self->expression_init, self->expression_init_Refman)
     if (self->expression_init->aux_variable_Dynamic != NULL) self->expression_init->aux_variable_Dynamic->_base._base._del(self->expression_init->aux_variable);
     LUMI_owner_dec_ref(self->expression_init->aux_variable_Refman);
     self->expression_init->aux_variable_Refman = aux_VariableExpression_1_Refman;
@@ -47491,10 +47508,10 @@ Returncode tl5_compiler_M_VariableInit_parse(tl5_compiler_M_VariableInit* self, 
     aux_VariableExpression_1 = NULL;
     aux_VariableExpression_1_Refman = NULL;
     aux_VariableExpression_1_Dynamic = NULL;
-    CHECK_REF(428, self, self_Refman)
-    CHECK_REF(428, self, self_Refman)
-    CHECK_REF(428, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(428, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
+    CHECK_REF(433, self, self_Refman)
+    CHECK_REF(433, self, self_Refman)
+    CHECK_REF(433, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(433, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
     aux_Ref_Manager = self->expression_init->aux_variable->variable_Refman;
     self->expression_init->aux_variable->variable_Refman = self->_base.variable_Refman;
     self->expression_init->aux_variable->variable_Dynamic = self->_base.variable_Dynamic;
@@ -47502,41 +47519,41 @@ Returncode tl5_compiler_M_VariableInit_parse(tl5_compiler_M_VariableInit* self, 
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     self->expression_init->aux_variable->variable = self->_base.variable;
-    CHECK_REF(429, self, self_Refman)
-    CHECK_REF(429, self->_base.variable, self->_base.variable_Refman)
-    CHECK_REF(430, self, self_Refman)
-    CHECK_REF(430, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(430, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
-    LUMI_err = tl5_compiler_M_TypeInstance_copy_new(self->_base.variable->type_instance, self->_base.variable->type_instance_Refman, &(self->expression_init->aux_variable->_base.result_type), &(self->expression_init->aux_variable->_base.result_type_Refman));
-    CHECK(429)
-    CHECK_REF(431, self, self_Refman)
-    CHECK_REF(431, self->_base.variable, self->_base.variable_Refman)
-    CHECK_REF(431, self, self_Refman)
-    CHECK_REF(431, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(431, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
-    self->expression_init->aux_variable->_base.access = self->_base.variable->access;
-    CHECK_REF(433, self, self_Refman)
-    CHECK_REF(433, self->_base.variable, self->_base.variable_Refman)
-    LUMI_err = tl5_compiler_M_access_is_only_var(self->_base.variable->access, &(aux_Bool_0));
-    CHECK(432)
-    CHECK_REF(432, self, self_Refman)
-    CHECK_REF(432, self->_base.variable, self->_base.variable_Refman)
-    CHECK_REF(432, self, self_Refman)
-    CHECK_REF(432, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(432, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
-    self->expression_init->aux_variable->_base.is_var = self->_base.variable->is_create && aux_Bool_0;
+    CHECK_REF(434, self, self_Refman)
+    CHECK_REF(434, self->_base.variable, self->_base.variable_Refman)
     CHECK_REF(435, self, self_Refman)
-    INIT_NEW(435, aux_ReferencePath_0, LUMI_alloc(sizeof(tl5_compiler_M_ReferencePath)));
-    LUMI_err = tl5_compiler_M_ReferencePath_new(aux_ReferencePath_0, aux_ReferencePath_0_Refman, self->_base.variable, self->_base.variable_Refman, self->_base.variable_Dynamic);
+    CHECK_REF(435, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(435, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
+    LUMI_err = tl5_compiler_M_TypeInstance_copy_new(self->_base.variable->type_instance, self->_base.variable->type_instance_Refman, &(self->expression_init->aux_variable->_base.result_type), &(self->expression_init->aux_variable->_base.result_type_Refman));
     CHECK(434)
+    CHECK_REF(436, self, self_Refman)
+    CHECK_REF(436, self->_base.variable, self->_base.variable_Refman)
+    CHECK_REF(436, self, self_Refman)
+    CHECK_REF(436, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(436, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
+    self->expression_init->aux_variable->_base.access = self->_base.variable->access;
+    CHECK_REF(438, self, self_Refman)
+    CHECK_REF(438, self->_base.variable, self->_base.variable_Refman)
+    LUMI_err = tl5_compiler_M_access_is_only_var(self->_base.variable->access, &(aux_Bool_0));
+    CHECK(437)
+    CHECK_REF(437, self, self_Refman)
+    CHECK_REF(437, self->_base.variable, self->_base.variable_Refman)
+    CHECK_REF(437, self, self_Refman)
+    CHECK_REF(437, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(437, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
+    self->expression_init->aux_variable->_base.is_var = self->_base.variable->is_create && aux_Bool_0;
+    CHECK_REF(440, self, self_Refman)
+    INIT_NEW(440, aux_ReferencePath_0, LUMI_alloc(sizeof(tl5_compiler_M_ReferencePath)));
+    LUMI_err = tl5_compiler_M_ReferencePath_new(aux_ReferencePath_0, aux_ReferencePath_0_Refman, self->_base.variable, self->_base.variable_Refman, self->_base.variable_Dynamic);
+    CHECK(439)
     aux_ReferencePath_1 = aux_ReferencePath_0;
     aux_ReferencePath_1_Refman = aux_ReferencePath_0_Refman;
     aux_ReferencePath_0 = NULL;
     aux_ReferencePath_0_Refman = NULL;
-    CHECK_REF(434, self, self_Refman)
-    CHECK_REF(434, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(434, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
-    CHECK_REF(434, self->expression_init->aux_variable->_base.result_type, self->expression_init->aux_variable->_base.result_type_Refman)
+    CHECK_REF(439, self, self_Refman)
+    CHECK_REF(439, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(439, self->expression_init->aux_variable, self->expression_init->aux_variable_Refman)
+    CHECK_REF(439, self->expression_init->aux_variable->_base.result_type, self->expression_init->aux_variable->_base.result_type_Refman)
     tl5_compiler_M_ReferencePath_Del(self->expression_init->aux_variable->_base.result_type->reference_path);
     LUMI_owner_dec_ref(self->expression_init->aux_variable->_base.result_type->reference_path_Refman);
     self->expression_init->aux_variable->_base.result_type->reference_path_Refman = aux_ReferencePath_1_Refman;
@@ -47571,16 +47588,16 @@ LUMI_cleanup:
 Returncode tl5_compiler_M_VariableInit_check_error_mark(tl5_compiler_M_VariableInit* self, Ref_Manager* self_Refman, tl5_compiler_M_VariableInit_Dynamic* self_Dynamic) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(438, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(443, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     if (tl5_compiler_M_glob->last_char == '!') {
-        CHECK_REF(439, self, self_Refman)
-        CHECK_REF(439, self->expression_init, self->expression_init_Refman)
+        CHECK_REF(444, self, self_Refman)
+        CHECK_REF(444, self->expression_init, self->expression_init_Refman)
         self->expression_init->_base._base.error_propagated = true;
-        CHECK_REF(440, self, self_Refman)
-        CHECK_REF(440, self->expression_init, self->expression_init_Refman)
+        CHECK_REF(445, self, self_Refman)
+        CHECK_REF(445, self->expression_init, self->expression_init_Refman)
         self->expression_init->_base._base.error_expected = true;
         LUMI_err = tl5_compiler_M_read_c();
-        CHECK(441)
+        CHECK(446)
     }
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
@@ -47595,12 +47612,12 @@ Returncode tl5_compiler_M_VariableInit_analyze(tl5_compiler_M_VariableInit* self
     Returncode LUMI_err = OK;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(444, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(444, self, self_Refman)
+    CHECK_REF(449, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(449, self, self_Refman)
     if ((void*)self->_base._base.parent == &(tl5_compiler_M_glob->root.global_init)) {
-        CHECK_REF(445, self, self_Refman)
-        CHECK_REF(445, self->_base.variable, self->_base.variable_Refman)
-        CHECK_REF(445, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(450, self, self_Refman)
+        CHECK_REF(450, self->_base.variable, self->_base.variable_Refman)
+        CHECK_REF(450, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
         aux_Ref_Manager = tl5_compiler_M_glob->current_module_Refman;
         tl5_compiler_M_glob->current_module_Refman = self->_base.variable->my_module_Refman;
         LUMI_inc_ref(tl5_compiler_M_glob->current_module_Refman);
@@ -47608,14 +47625,14 @@ Returncode tl5_compiler_M_VariableInit_analyze(tl5_compiler_M_VariableInit* self
         aux_Ref_Manager = NULL;
         tl5_compiler_M_glob->current_module = self->_base.variable->my_module;
     }
-    CHECK_REF(446, self, self_Refman)
-    if (self->expression_init_Dynamic == NULL) RAISE(446, empty_object)
+    CHECK_REF(451, self, self_Refman)
+    if (self->expression_init_Dynamic == NULL) RAISE(451, empty_object)
     LUMI_err = self->expression_init_Dynamic->_base._base._base.analyze(&(self->expression_init->_base._base._base), self->expression_init_Refman, &(self->expression_init_Dynamic->_base._base._base));
-    CHECK(446)
-    CHECK_REF(447, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(447, self, self_Refman)
+    CHECK(451)
+    CHECK_REF(452, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(452, self, self_Refman)
     if ((void*)self->_base._base.parent == &(tl5_compiler_M_glob->root.global_init)) {
-        CHECK_REF(448, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        CHECK_REF(453, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
         aux_Ref_Manager = tl5_compiler_M_glob->current_module_Refman;
         tl5_compiler_M_glob->current_module_Refman = NULL;
         LUMI_inc_ref(tl5_compiler_M_glob->current_module_Refman);
@@ -47623,19 +47640,19 @@ Returncode tl5_compiler_M_VariableInit_analyze(tl5_compiler_M_VariableInit* self
         aux_Ref_Manager = NULL;
         tl5_compiler_M_glob->current_module = NULL;
     }
-    CHECK_REF(450, self, self_Refman)
-    CHECK_REF(450, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(449, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(449, self, self_Refman)
-    CHECK_REF(449, self->_base.variable, self->_base.variable_Refman)
-    CHECK_REF(449, self->_base.variable->type_instance, self->_base.variable->type_instance_Refman)
+    CHECK_REF(455, self, self_Refman)
+    CHECK_REF(455, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(454, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(454, self, self_Refman)
+    CHECK_REF(454, self->_base.variable, self->_base.variable_Refman)
+    CHECK_REF(454, self->_base.variable->type_instance, self->_base.variable->type_instance_Refman)
     if (((void*)self->_base.variable->type_instance->type_data == tl5_compiler_M_glob->type_func) && (! (self->expression_init->arguments.parameters.first != NULL && self->expression_init->arguments.parameters.first_Refman->value != NULL))) {
-        CHECK_REF(451, self, self_Refman)
-        CHECK_REF(451, self->_base.variable, self->_base.variable_Refman)
+        CHECK_REF(456, self, self_Refman)
+        CHECK_REF(456, self->_base.variable, self->_base.variable_Refman)
         self->_base.variable->is_initialized = false;
     }
     LUMI_err = tl5_compiler_M_VariableCreate_analyze(&(self->_base), self_Refman, &(self_Dynamic->_base));
-    CHECK(452)
+    CHECK(457)
 LUMI_cleanup:
     LUMI_dec_ref(self_Refman);
     return LUMI_err;
@@ -47649,15 +47666,15 @@ Returncode tl5_compiler_M_VariableInit_check_memory(tl5_compiler_M_VariableInit*
     Returncode LUMI_err = OK;
     LUMI_inc_ref(self_Refman);
     LUMI_inc_ref(refs_Refman);
-    CHECK_REF(455, self, self_Refman)
-    if (self->expression_init_Dynamic == NULL) RAISE(455, empty_object)
+    CHECK_REF(460, self, self_Refman)
+    if (self->expression_init_Dynamic == NULL) RAISE(460, empty_object)
     LUMI_err = self->expression_init_Dynamic->_base._base._base.check_memory(&(self->expression_init->_base._base._base), self->expression_init_Refman, &(self->expression_init_Dynamic->_base._base._base), refs, refs_Refman);
-    CHECK(455)
-    CHECK_REF(456, self, self_Refman)
+    CHECK(460)
+    CHECK_REF(461, self, self_Refman)
     LUMI_err = tl5_compiler_M_ReferenceMemoryList_add(refs, refs_Refman, self->_base.variable, self->_base.variable_Refman, self->_base.variable_Dynamic);
-    CHECK(456)
+    CHECK(461)
     LUMI_err = tl5_compiler_M_VariableCreate_check_memory(&(self->_base), self_Refman, &(self_Dynamic->_base), refs, refs_Refman);
-    CHECK(457)
+    CHECK(462)
 LUMI_cleanup:
     LUMI_dec_ref(refs_Refman);
     LUMI_dec_ref(self_Refman);
@@ -47680,39 +47697,39 @@ Returncode tl5_compiler_M_VariableInit_write(tl5_compiler_M_VariableInit* self, 
     String* aux_String_2 = NULL;
     Ref_Manager* aux_String_2_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(461, self, self_Refman)
-    CHECK_REF(461, self->expression_init, self->expression_init_Refman)
-    CHECK_REF(460, self, self_Refman)
-    CHECK_REF(460, self->_base.variable, self->_base.variable_Refman)
-    CHECK_REF(460, self->_base.variable->type_instance, self->_base.variable->type_instance_Refman)
-    CHECK_REF(460, self->_base.variable->type_instance->type_data, self->_base.variable->type_instance->type_data_Refman)
+    CHECK_REF(466, self, self_Refman)
+    CHECK_REF(466, self->expression_init, self->expression_init_Refman)
+    CHECK_REF(465, self, self_Refman)
+    CHECK_REF(465, self->_base.variable, self->_base.variable_Refman)
+    CHECK_REF(465, self->_base.variable->type_instance, self->_base.variable->type_instance_Refman)
+    CHECK_REF(465, self->_base.variable->type_instance->type_data, self->_base.variable->type_instance->type_data_Refman)
     if (self->_base.variable->type_instance->type_data->is_primitive && (! (self->expression_init->arguments.parameters.first != NULL && self->expression_init->arguments.parameters.first_Refman->value != NULL))) {
         goto LUMI_cleanup;
     }
-    CHECK_REF(463, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(463, self, self_Refman)
-    if ((void*)self->_base._base.parent == &(tl5_compiler_M_glob->root.global_init)) {
-        INIT_STRING_CONST(464, aux_String_0, "#define LUMI_FILE_NAME ");
-        LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-        CHECK(464)
-        CHECK_REF(465, self, self_Refman)
-        CHECK_REF(465, self->_base.variable, self->_base.variable_Refman)
-        LUMI_err = tl5_compiler_M_write_string_literal(self->_base.variable->_base._base.input_file_name, self->_base.variable->_base._base.input_file_name_Refman);
-        CHECK(465)
-        INIT_STRING_CONST(466, aux_String_1, "\n");
-        LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-        CHECK(466)
-    }
-    CHECK_REF(467, self, self_Refman)
-    if (self->expression_init_Dynamic == NULL) RAISE(467, empty_object)
-    LUMI_err = self->expression_init_Dynamic->_base._base._base.write(&(self->expression_init->_base._base._base), self->expression_init_Refman, &(self->expression_init_Dynamic->_base._base._base));
-    CHECK(467)
     CHECK_REF(468, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     CHECK_REF(468, self, self_Refman)
     if ((void*)self->_base._base.parent == &(tl5_compiler_M_glob->root.global_init)) {
-        INIT_STRING_CONST(469, aux_String_2, "#undef LUMI_FILE_NAME\n");
-        LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
+        INIT_STRING_CONST(469, aux_String_0, "#define LUMI_FILE_NAME ");
+        LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
         CHECK(469)
+        CHECK_REF(470, self, self_Refman)
+        CHECK_REF(470, self->_base.variable, self->_base.variable_Refman)
+        LUMI_err = tl5_compiler_M_write_string_literal(self->_base.variable->_base._base.input_file_name, self->_base.variable->_base._base.input_file_name_Refman);
+        CHECK(470)
+        INIT_STRING_CONST(471, aux_String_1, "\n");
+        LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
+        CHECK(471)
+    }
+    CHECK_REF(472, self, self_Refman)
+    if (self->expression_init_Dynamic == NULL) RAISE(472, empty_object)
+    LUMI_err = self->expression_init_Dynamic->_base._base._base.write(&(self->expression_init->_base._base._base), self->expression_init_Refman, &(self->expression_init_Dynamic->_base._base._base));
+    CHECK(472)
+    CHECK_REF(473, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(473, self, self_Refman)
+    if ((void*)self->_base._base.parent == &(tl5_compiler_M_glob->root.global_init)) {
+        INIT_STRING_CONST(474, aux_String_2, "#undef LUMI_FILE_NAME\n");
+        LUMI_err = tl5_compiler_M_write(aux_String_2, aux_String_2_Refman);
+        CHECK(474)
     }
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_2_Refman);
@@ -48965,6 +48982,9 @@ Returncode tl5_compiler_M_SyntaxTreeMainFunction_parse(tl5_compiler_M_SyntaxTree
     String aux_String_0_Var = {0};
     String* aux_String_0 = NULL;
     Ref_Manager* aux_String_0_Refman = NULL;
+    String aux_String_1_Var = {0};
+    String* aux_String_1 = NULL;
+    Ref_Manager* aux_String_1_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
     CHECK_REF(426, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
@@ -48979,11 +48999,22 @@ Returncode tl5_compiler_M_SyntaxTreeMainFunction_parse(tl5_compiler_M_SyntaxTree
     CHECK_REF(427, self, self_Refman)
     LUMI_err = tl5_compiler_M_string_new_copy(aux_String_0, aux_String_0_Refman, &(self->_base.name), &(self->_base.name_Refman));
     CHECK(427)
-    CHECK_REF(428, self, self_Refman)
-    self->_base.arguments.has_error = true;
+    CHECK_REF(428, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    if (tl5_compiler_M_glob->last_char == '!') {
+        CHECK_REF(429, self, self_Refman)
+        self->_base.arguments.has_error = true;
+        CHECK_REF(430, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+        tl5_compiler_M_glob->root.global_init._base.arguments.has_error = true;
+        LUMI_err = tl5_compiler_M_read_c();
+        CHECK(431)
+    }
+    INIT_STRING_CONST(432, aux_String_1, "main");
+    LUMI_err = tl5_compiler_M_SyntaxTreeNode_expect_new_line(&(self->_base._base._base._base), self_Refman, &(self_Dynamic->_base._base._base._base), aux_String_1, aux_String_1_Refman);
+    CHECK(432)
     LUMI_err = tl5_compiler_M_SyntaxTreeFunction_parse_body(&(self->_base), self_Refman, &(self_Dynamic->_base));
-    CHECK(429)
+    CHECK(433)
 LUMI_cleanup:
+    LUMI_var_dec_ref(aux_String_1_Refman);
     LUMI_var_dec_ref(aux_String_0_Refman);
     LUMI_dec_ref(self_Refman);
     return LUMI_err;
@@ -49002,16 +49033,18 @@ Returncode tl5_compiler_M_SyntaxTreeMainFunction_write(tl5_compiler_M_SyntaxTree
     String* aux_String_1 = NULL;
     Ref_Manager* aux_String_1_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    INIT_STRING_CONST(436, aux_String_0, "\nUSER_MAIN_HEADER");
+    INIT_STRING_CONST(440, aux_String_0, "\nUSER_MAIN_HEADER");
     LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(436)
+    CHECK(440)
+    CHECK_REF(441, self, self_Refman)
+    self->_base.arguments.has_error = true;
     LUMI_err = tl5_compiler_M_SyntaxTreeFunction_write_block(&(self->_base), self_Refman, &(self_Dynamic->_base));
-    CHECK(437)
+    CHECK(442)
     LUMI_err = tl5_compiler_M_SyntaxTreeFunction_write_post_func(&(self->_base), self_Refman, &(self_Dynamic->_base));
-    CHECK(438)
-    INIT_STRING_CONST(439, aux_String_1, "\nMAIN_FUNC\n");
+    CHECK(443)
+    INIT_STRING_CONST(444, aux_String_1, "\nMAIN_FUNC\n");
     LUMI_err = tl5_compiler_M_write(aux_String_1, aux_String_1_Refman);
-    CHECK(439)
+    CHECK(444)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_1_Refman);
     LUMI_var_dec_ref(aux_String_0_Refman);
@@ -49029,16 +49062,16 @@ Returncode tl5_compiler_M_SyntaxTreeMainFunction_write_block_body(tl5_compiler_M
     String* aux_String_0 = NULL;
     Ref_Manager* aux_String_0_Refman = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(442, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(447, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
     LUMI_err = tl5_compiler_M_GlobalInit_write(&(tl5_compiler_M_glob->root.global_init), tl5_compiler_M_glob_Refman, &tl5_compiler_M_GlobalInit_dynamic);
-    CHECK(442)
+    CHECK(447)
     LUMI_err = tl5_compiler_M_SyntaxTreeFunction_write_pre_func(&(self->_base), self_Refman, &(self_Dynamic->_base));
-    CHECK(443)
-    INIT_STRING_CONST(444, aux_String_0, "\n");
+    CHECK(448)
+    INIT_STRING_CONST(449, aux_String_0, "\n");
     LUMI_err = tl5_compiler_M_write(aux_String_0, aux_String_0_Refman);
-    CHECK(444)
+    CHECK(449)
     LUMI_err = tl5_compiler_M_SyntaxTreeBlock_write_block_body(&(self->_base._base), self_Refman, &(self_Dynamic->_base._base));
-    CHECK(445)
+    CHECK(450)
 LUMI_cleanup:
     LUMI_var_dec_ref(aux_String_0_Refman);
     LUMI_dec_ref(self_Refman);
@@ -49062,21 +49095,21 @@ Returncode tl5_compiler_M_LineCount_build_values(tl5_compiler_M_LineCount* self,
     Ref_Manager* aux_Array_1_Refman = NULL;
     Ref_Manager* aux_Ref_Manager = NULL;
     LUMI_inc_ref(self_Refman);
-    CHECK_REF(471, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    CHECK_REF(471, self, self_Refman)
+    CHECK_REF(476, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    CHECK_REF(476, self, self_Refman)
     aux_Ref_Manager = self->filename_Refman;
     self->filename_Refman = tl5_compiler_M_glob->input_file_name_Refman;
     LUMI_inc_ref(self->filename_Refman);
     LUMI_dec_ref(aux_Ref_Manager);
     aux_Ref_Manager = NULL;
     self->filename = tl5_compiler_M_glob->input_file_name;
-    CHECK_REF(472, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
-    INIT_NEW(472, aux_Array_0, LUMI_new_array(tl5_compiler_M_glob->line_number + 1, sizeof(Bool)));
+    CHECK_REF(477, tl5_compiler_M_glob, tl5_compiler_M_glob_Refman)
+    INIT_NEW(477, aux_Array_0, LUMI_new_array(tl5_compiler_M_glob->line_number + 1, sizeof(Bool)));
     aux_Array_1 = aux_Array_0;
     aux_Array_1_Refman = aux_Array_0_Refman;
     aux_Array_0 = NULL;
     aux_Array_0_Refman = NULL;
-    CHECK_REF(472, self, self_Refman)
+    CHECK_REF(477, self, self_Refman)
         LUMI_owner_dec_ref(self->line_needs_cover_Refman);
     self->line_needs_cover_Refman = aux_Array_1_Refman;
     self->line_needs_cover = aux_Array_1;
@@ -58051,7 +58084,7 @@ Returncode tl5_compiler_M_write_global(String* text, Ref_Manager* text_Refman) {
     Returncode LUMI_err = OK;
     LUMI_inc_ref(text_Refman);
     LUMI_err = tl5_compiler_M_write(text, text_Refman);
-    CHECK(477)
+    CHECK(482)
 LUMI_cleanup:
     LUMI_dec_ref(text_Refman);
     return LUMI_err;

--- a/docs/hello-world.5.lm
+++ b/docs/hello-world.5.lm
@@ -3,5 +3,5 @@ module hello-world
 func ! show()
     sys.println(user "hello world")!
 
-main
+main!
     show()!


### PR DESCRIPTION
Changes:

* fix memory bug in invalid swapping `invalid :=: valid`
* protect global variables the same way as fields

Fixes #143.

- [x] Changes fully completed + unit tested + integration tested + documented
